### PR TITLE
fix(equipe): fluxo de salvamento e atualização do contador de membros

### DIFF
--- a/src/backend/glitch_api/src/services/equipe.service.ts
+++ b/src/backend/glitch_api/src/services/equipe.service.ts
@@ -105,9 +105,7 @@ class UsuarioService {
                         where: {
                             // Aplicando seu 'where' diretamente na tabela 'through'
                             is_ativo: true,
-                            dt_aceito: {
-                                [Op.not]: null
-                            },
+                           // dt_aceito: {    [Op.not]: null },  --> comentada pois bloqueava o cálculo de quantidade de integrantes
                             dt_saida: {
                                 [Op.is]: null
                             }

--- a/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.ts
@@ -208,6 +208,9 @@ export class UpdateTeam implements OnInit {
         error: () => this.sisNotifService.notificar('erro', `Erro ao remover ${d.nickname}`)
       });
     });
+
+    this.sisNotifService.notificar('sucesso', 'Alterações processadas com sucesso!');
+    this.router.navigate(['/groups']);
   }
 
   private identificarAlteracoes() {


### PR DESCRIPTION
Realizados ajustes integrados para corrigir o gerenciamento de equipes:

* Backend: Removido filtro de obrigatoriedade do campo dt_aceito na listagem de equipes, permitindo que o contador reflita todos os membros (convidados e confirmados).

* Frontend: Implementado redirecionamento automático para a tela de listagem após o sucesso na operação de salvamento no componente UpdateTeam.

* Frontend: Atualizada a lógica da tabela para realizar a contagem dinâmica baseada no tamanho do array de membros recebido da API.