### PR TITLE
Fixes backend

### DIFF
--- a/src/backend/glitch_api/migrations/20260505225517-add-tipo-to-membros-equipe.js
+++ b/src/backend/glitch_api/migrations/20260505225517-add-tipo-to-membros-equipe.js
@@ -1,0 +1,18 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("membros_equipe", "tipo", {
+      type: Sequelize.ENUM("convite", "solicitacao"),
+      allowNull: false,
+      defaultValue: "convite", // registros existentes serão tratados como convite
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("membros_equipe", "tipo");
+    await queryInterface.sequelize.query(
+      'DROP TYPE IF EXISTS "enum_membros_equipe_tipo";',
+    );
+  },
+};

--- a/src/backend/glitch_api/src/controllers/equipe.controller.ts
+++ b/src/backend/glitch_api/src/controllers/equipe.controller.ts
@@ -2,222 +2,234 @@ import { Request, Response } from "express";
 import equipeService from "../services/equipe.service";
 
 class EquipeController {
-    public async addEquipe(req: Request, res: Response): Promise<any> {
-        if (!req.usuario) {
-            res.status(401).json({ message: "Não autorizado" })
-            return;
-        }
-        if (!req.body.nome) {
-            res.status(400).json({ message: "Faltam informações" })
-            return;
-        }
-        let nome = req.body.nome;
-        try {
-            let equipe = await equipeService.addEquipe(nome, req.usuario.id);
+  public async addEquipe(req: Request, res: Response): Promise<any> {
+    if (!req.usuario) {
+      res.status(401).json({ message: "Não autorizado" });
+      return;
+    }
+    if (!req.body.nome) {
+      res.status(400).json({ message: "Faltam informações" });
+      return;
+    }
+    let nome = req.body.nome;
+    try {
+      let equipe = await equipeService.addEquipe(nome, req.usuario.id);
 
-            res.status(201).json({ message: 'Criado', equipe: equipe.dataValues.id })
-        } catch (e) {
-            res.status(500).json({ message: "Erro interno do servidor" })
-            console.log(e)
-        }
+      res.status(201).json({ message: "Criado", equipe: equipe.dataValues.id });
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+      console.log(e);
+    }
+  }
+
+  public async inviteJogador(req: Request, res: Response): Promise<any> {
+    if (!req.usuario) {
+      res.status(401).json({ message: "Não autorizado" });
+      return;
+    }
+    let equipe: string = req.body.equipe;
+    let jogador: {
+      nickname: string;
+      is_titular: boolean;
+      is_lider: boolean;
+      funcao: string;
+    } = req.body.jogador;
+    if (!equipe || !jogador) {
+      res.status(400).json({ message: "Requisição mal formada" });
+      return;
+    }
+    try {
+      //Verifica se quem está chamando é líder da equipe
+      const isLider = await equipeService.verificarSeLider(
+        req.usuario.id,
+        equipe,
+      );
+      const tipo: "convite" | "solicitacao" = isLider
+        ? "convite"
+        : "solicitacao";
+
+      await equipeService.convidarJogador(equipe, jogador, tipo);
+      res.status(200).json({
+        message: isLider ? "Jogador convidado" : "Solicitação enviada",
+      });
+    } catch (e) {
+      res.status(500).json({ message: "Erro ao processar requisição" });
+    }
+  }
+
+  public async getEquipes(req: Request, res: Response): Promise<any> {
+    if (!req.usuario) {
+      res.status(401).json({ message: "Não autorizado" });
+      return;
+    }
+    try {
+      let equipes = await equipeService.getEquipes();
+      res.status(200).json(equipes);
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  }
+
+  public async getEquipePorId(req: Request, res: Response): Promise<any> {
+    let id = req.params.id;
+    if (!id) {
+      res.status(400).json({ message: "Necessário informar o ID" });
+      return;
+    }
+    try {
+      let equipe = await equipeService.getEquipePorId(id);
+      console.log(equipe);
+      res.status(200).json(equipe);
+    } catch (e) {
+      res.status(500).json({ messge: "Erro do servidor", error: e });
+    }
+  }
+
+  public async getInvites(req: Request, res: Response) {
+    if (!req.usuario) {
+      res.status(401).json({ message: "Não autorizado" });
+      return;
+    }
+    try {
+      let invites = await equipeService.getInvites(req.usuario.id);
+      res.status(200).json(invites);
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  }
+
+  public async aceitarInvite(req: Request, res: Response): Promise<any> {
+    if (!req.usuario) {
+      res.status(401).json({ message: "Não autorizado" });
+      return;
+    }
+    let usuario = req.usuario.id;
+    let equipe = req.body.equipe;
+    if (!equipe) {
+      res.status(400).json({ message: "Necessário resposta e equipe" });
+      return;
+    }
+    try {
+      let usuarioAlvo = req.body.usuarioAlvo;
+
+      await equipeService.answerInvite(usuario, equipe, usuarioAlvo, true);
+      res.status(200).json({ message: "OK" });
+    } catch (e) {
+      res.status(500).json({ message: "Erro do servidor" });
+    }
+  }
+
+  public async recusarInvite(req: Request, res: Response): Promise<any> {
+    if (!req.usuario) {
+      res.status(401).json({ message: "Não autorizado" });
+      return;
+    }
+    let usuario = req.usuario.id;
+    let equipe = req.body.equipe;
+    if (!equipe) {
+      res.status(400).json({ message: "Necessário resposta e equipe" });
+      return;
+    }
+    try {
+      let usuarioAlvo = req.body.usuarioAlvo;
+
+      await equipeService.answerInvite(usuario, equipe, usuarioAlvo, false);
+      res.status(200).json({ message: "OK" });
+    } catch (e) {
+      res.status(500).json({ message: "Erro do servidor" });
+    }
+  }
+
+  public async updateEquipe(req: Request, res: Response): Promise<any> {
+    const id = req.body.id;
+    const novo_nome = req.body.novoNome;
+    if (!id || !novo_nome) {
+      res.status(400).json({ message: "Dados incompletos" });
+      return;
+    }
+    try {
+      switch (await equipeService.updateEquipe(id, novo_nome)) {
+        case "200":
+          res.status(200).json({ message: "Ok" });
+          break;
+        case "404":
+          res.status(404).json({ message: "Não encontrado" });
+          break;
+        case "400":
+          res.status(400).json({ message: "Nome já utilizado" });
+      }
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  }
+
+  public async removeEquipe(req: Request, res: Response): Promise<any> {
+    const id = req.params.id;
+    if (!id) {
+      res.status(400).json({ message: "Dados incompletos" });
+      return;
+    }
+    try {
+      await equipeService.removeEquipe(id);
+      res.status(200).json({ message: "Ok" });
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  }
+
+  public async updateMembro(req: Request, res: Response): Promise<any> {
+    const membro = req.body.membro;
+    const equipe = req.body.equipe;
+    if (!membro.nickname || !equipe) {
+      res.status(400).json({ message: "Dados incompletos" });
+      return;
+    }
+    try {
+      switch (await equipeService.updateMembro(membro, equipe)) {
+        case "200":
+          res.status(200).json({ message: "Ok" });
+          break;
+        case "404":
+          res.status(404).json({ message: "Não encontrado" });
+          break;
+      }
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  }
+
+  public async removeMembro(req: Request, res: Response): Promise<any> {
+    const nickname = req.body.nickname;
+    const equipe = req.body.equipe;
+    if (!nickname || !equipe) {
+      res.status(400).json({ message: "Dados incompletos" });
+      return;
+    }
+    try {
+      await equipeService.removeMembro(nickname, equipe);
+      res.status(200).json({ message: "Ok" });
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  }
+
+  public async getMinhasEquipes(req: Request, res: Response): Promise<any> {
+    if (!req.usuario) {
+      res.status(401).json({ message: "Não foi possível autenticar" });
+      return;
     }
 
-    public async inviteJogador(req: Request, res: Response): Promise<any> {
-        let equipe: string = req.body.equipe
-        let jogador: {nickname:string,is_titular:boolean,is_lider:boolean,funcao:string} = req.body.jogador
-        if (!equipe || !jogador) {
-            res.status(400).json({ message: 'Requisição mal formada' })
-            return;
-        }
-        try {
-            await equipeService.convidarJogador(equipe, jogador);
-            res.status(200).json({ message: "Jogador convidado" })
-        } catch (e) {
-            res.status(500).json({ message: "Erro ao convidar" })
-        }
+    const eu = req.usuario.id;
+
+    try {
+      let equipes = await equipeService.getMinhasEquipes(eu);
+
+      res.status(200).json(equipes);
+    } catch (e) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+      console.error(e);
     }
-
-    public async getEquipes(req: Request, res: Response): Promise<any> {
-        if (!req.usuario) {
-            res.status(401).json({ message: 'Não autorizado' })
-            return;
-        }
-        try {
-            let equipes = await equipeService.getEquipes()
-            res.status(200).json(equipes)
-        } catch (e) {
-            res.status(500).json({ message: 'Erro interno do servidor' })
-        }
-    }
-
-    public async getEquipePorId(req: Request, res: Response): Promise<any> {
-        let id = req.params.id;
-        if (!id) {
-            res.status(400).json({ message: 'Necessário informar o ID' })
-            return;
-        }
-        try {
-            let equipe = await equipeService.getEquipePorId(id);
-            console.log(equipe)
-            res.status(200).json(equipe)
-        } catch (e) {
-            res.status(500).json({ messge: 'Erro do servidor', error: e })
-        }
-    }
-
-    public async getInvites(req: Request, res: Response) {
-        if (!req.usuario) {
-            res.status(401).json({ message: 'Não autorizado' })
-            return;
-        }
-        try {
-            let invites = await equipeService.getInvites(req.usuario.id)
-            res.status(200).json(invites)
-        } catch (e) {
-            res.status(500).json({ message: 'Erro interno do servidor' })
-        }
-    }
-
-    public async aceitarInvite(req: Request, res: Response): Promise<any> {
-        if (!req.usuario) {
-            res.status(401).json({ message: 'Não autorizado' })
-            return;
-        }
-        let usuario = req.usuario.id
-        let equipe = req.body.equipe;
-        if (!equipe) {
-            res.status(400).json({ message: 'Necessário resposta e equipe' })
-            return;
-        }
-        try {
-            await equipeService.answerInvite(usuario, equipe, true)
-            res.status(200).json({ message: 'OK' })
-        } catch (e) {
-            res.status(500).json({ message: 'Erro do servidor' })
-        }
-    }
-
-    public async recusarInvite(req: Request, res: Response): Promise<any> {
-        if (!req.usuario) {
-            res.status(401).json({ message: 'Não autorizado' })
-            return;
-        }
-        let usuario = req.usuario.id
-        let equipe = req.body.equipe;
-        if (!equipe) {
-            res.status(400).json({ message: 'Necessário resposta e equipe' })
-            return;
-        }
-        try {
-            await equipeService.answerInvite(usuario, equipe, false)
-            res.status(200).json({ message: 'OK' })
-        } catch (e) {
-            res.status(500).json({ message: 'Erro do servidor' })
-        }
-    }
-
-    public async updateEquipe(req: Request, res: Response): Promise<any> {
-        const id = req.body.id;
-        const novo_nome = req.body.novoNome
-        if (!id || !novo_nome) {
-            res.status(400).json({ message: 'Dados incompletos' })
-            return;
-        }
-        try {
-            switch (await equipeService.updateEquipe(id, novo_nome)) {
-                case '200':
-                    res.status(200).json({ message: 'Ok' })
-                    break;
-                case '404':
-                    res.status(404).json({ message: 'Não encontrado' })
-                    break;
-                case '400':
-                    res.status(400).json({ message: 'Nome já utilizado' })
-            }
-        } catch (e) {
-            res.status(500).json({ message: 'Erro interno do servidor' })
-        }
-    }
-
-    public async removeEquipe(req: Request, res: Response): Promise<any> {
-        const id = req.params.id
-        if (!id) {
-            res.status(400).json({ message: 'Dados incompletos' })
-            return;
-        }
-        try {
-            await equipeService.removeEquipe(id)
-            res.status(200).json({ message: 'Ok' })
-
-        } catch (e) {
-            res.status(500).json({ message: 'Erro interno do servidor' })
-        }
-    }
-
-    public async updateMembro(req: Request, res: Response): Promise<any> {
-        const membro = req.body.membro;
-        const equipe = req.body.equipe;
-        if (!membro.nickname || !equipe) {
-            res.status(400).json({ message: 'Dados incompletos' })
-            return;
-        }
-        try {
-
-            switch (await equipeService.updateMembro(membro,equipe)) {
-                case '200':
-                    res.status(200).json({ message: 'Ok' })
-                    break;
-                case '404':
-                    res.status(404).json({ message: 'Não encontrado' })
-                    break;
-            }
-        } catch (e) {
-            res.status(500).json({ message: 'Erro interno do servidor' })
-        }
-    }
-
-    public async removeMembro(req: Request, res: Response): Promise<any> {
-        const nickname = req.body.nickname;
-        const equipe = req.body.equipe;
-        if (!nickname || !equipe) {
-            res.status(400).json({ message: 'Dados incompletos' })
-            return;
-        }
-        try {
-            await equipeService.removeMembro(nickname,equipe)
-            res.status(200).json({ message: 'Ok' })
-
-        } catch (e) {
-            res.status(500).json({ message: 'Erro interno do servidor' })
-        }
-    }
-
-
-    public async getMinhasEquipes(req:Request,res:Response):Promise<any>{
-
-        if(!req.usuario){
-            res.status(401).json({message:"Não foi possível autenticar"})
-            return;
-        }
-
-        const eu = req.usuario.id;
-
-        try{
-
-            let equipes = await equipeService.getMinhasEquipes(eu)
-
-            res.status(200).json(equipes)
-
-        }catch(e){
-            res.status(500).json({message:"Erro interno do servidor"})
-            console.error(e)
-        }
-
-    }
-
-
-
-
+  }
 }
 
 export default new EquipeController();

--- a/src/backend/glitch_api/src/models/index.models.ts
+++ b/src/backend/glitch_api/src/models/index.models.ts
@@ -1,10 +1,10 @@
 // src/models/index.ts
 
-import { sequelize } from '../config/database.config';
+import { sequelize } from "../config/database.config";
 
 // Importa todos os models das subpastas
-import * as PessoasModels from './pessoas/index.pessoas';
-import * as TorneiosModels from './torneios/index.torneios';
+import * as PessoasModels from "./pessoas/index.pessoas";
+import * as TorneiosModels from "./torneios/index.torneios";
 
 // Consolida todos os models em um único objeto para fácil acesso
 const models = {
@@ -29,8 +29,14 @@ export type AppModels = typeof models;
 // Pessoas <-> Usuarios (1 para 1)
 // A tabela 'usuarios' tem 'pessoa_id'
 if (models.Usuarios && models.Pessoas) {
-  models.Usuarios.belongsTo(models.Pessoas, { foreignKey: 'pessoa_id', as: 'pessoa' });
-  models.Pessoas.hasOne(models.Usuarios, { foreignKey: 'pessoa_id', as: 'usuario' });
+  models.Usuarios.belongsTo(models.Pessoas, {
+    foreignKey: "pessoa_id",
+    as: "pessoa",
+  });
+  models.Pessoas.hasOne(models.Usuarios, {
+    foreignKey: "pessoa_id",
+    as: "usuario",
+  });
 }
 
 // Usuarios <-> Equipes (N para M)
@@ -38,70 +44,109 @@ if (models.Usuarios && models.Pessoas) {
 if (models.Usuarios && models.Equipes && models.MembrosEquipe) {
   models.Usuarios.belongsToMany(models.Equipes, {
     through: models.MembrosEquipe,
-    foreignKey: 'usuario_id',
-    otherKey: 'equipe_id',
-    as: 'equipes',
+    foreignKey: "usuario_id",
+    otherKey: "equipe_id",
+    as: "equipes",
   });
   models.Equipes.belongsToMany(models.Usuarios, {
     through: models.MembrosEquipe,
-    foreignKey: 'equipe_id',
-    otherKey: 'usuario_id',
-    as: 'membros',
+    foreignKey: "equipe_id",
+    otherKey: "usuario_id",
+    as: "membros",
   });
 }
 
 // Diz que MembrosEquipe PERTENCE A um Usuario
-    models.MembrosEquipe.belongsTo(models.Usuarios, {
-        foreignKey: 'usuario_id',
-        as: 'membro' // <--- Este 'as' DEVE ser o mesmo da sua query
-    });
-    
-    // Opcional, mas bom para consistência:
-    // Diz que MembrosEquipe PERTENCE A uma Equipe
-    models.MembrosEquipe.belongsTo(models.Equipes, {
-        foreignKey: 'equipe_id',
-        as: 'equipe' 
-    });
-    
-    // Opcional: Você também pode definir o 'outro lado'
-    models.Usuarios.hasMany(models.MembrosEquipe, { foreignKey: 'usuario_id', as: 'associacoesEquipe' });
-    models.Equipes.hasMany(models.MembrosEquipe, { foreignKey: 'equipe_id', as: 'associacoesMembro' });
+models.MembrosEquipe.belongsTo(models.Usuarios, {
+  foreignKey: "usuario_id",
+  as: "membro", // <--- Este 'as' DEVE ser o mesmo da sua query
+});
 
+// Opcional, mas bom para consistência:
+// Diz que MembrosEquipe PERTENCE A uma Equipe
+models.MembrosEquipe.belongsTo(models.Equipes, {
+  foreignKey: "equipe_id",
+  as: "equipe",
+});
+
+// Opcional: Você também pode definir o 'outro lado'
+models.Usuarios.hasMany(models.MembrosEquipe, {
+  foreignKey: "usuario_id",
+  as: "associacoesEquipe",
+});
+models.Equipes.hasMany(models.MembrosEquipe, {
+  foreignKey: "equipe_id",
+  as: "associacoesMembro",
+});
+models.Equipes.hasMany(models.MembrosEquipe, {
+  foreignKey: "equipe_id",
+  as: "membrosAtivos",
+});
 // --- Associações de Torneios ---
 
 // Torneios <-> Jogos (N para 1)
 // A tabela 'torneios' tem 'jogo_id'
 if (models.Torneios && models.Jogos) {
-  models.Torneios.belongsTo(models.Jogos, { foreignKey: 'jogo_id', as: 'jogo' });
-  models.Jogos.hasMany(models.Torneios, { foreignKey: 'jogo_id', as: 'torneios' });
+  models.Torneios.belongsTo(models.Jogos, {
+    foreignKey: "jogo_id",
+    as: "jogo",
+  });
+  models.Jogos.hasMany(models.Torneios, {
+    foreignKey: "jogo_id",
+    as: "torneios",
+  });
 }
 
 // Torneios <-> Usuarios (N para 1 - Responsável)
 // A tabela 'torneios' tem 'usuario_responsavel_id'
 if (models.Torneios && models.Usuarios) {
-  models.Torneios.belongsTo(models.Usuarios, { foreignKey: 'usuario_responsavel_id', as: 'responsavel' });
-  models.Usuarios.hasMany(models.Torneios, { foreignKey: 'usuario_responsavel_id', as: 'torneios_responsaveis' });
+  models.Torneios.belongsTo(models.Usuarios, {
+    foreignKey: "usuario_responsavel_id",
+    as: "responsavel",
+  });
+  models.Usuarios.hasMany(models.Torneios, {
+    foreignKey: "usuario_responsavel_id",
+    as: "torneios_responsaveis",
+  });
 }
 
 // Torneios <-> ConfigsInscricao (1 para 1)
 // A tabela 'configs_inscricao' tem 'torneio_id'
 if (models.ConfigsInscricao && models.Torneios) {
-  models.Torneios.hasOne(models.ConfigsInscricao, { foreignKey: 'torneio_id', as: 'configuracao_inscricao' });
-  models.ConfigsInscricao.belongsTo(models.Torneios, { foreignKey: 'torneio_id', as: 'torneio' });
+  models.Torneios.hasOne(models.ConfigsInscricao, {
+    foreignKey: "torneio_id",
+    as: "configuracao_inscricao",
+  });
+  models.ConfigsInscricao.belongsTo(models.Torneios, {
+    foreignKey: "torneio_id",
+    as: "torneio",
+  });
 }
 
 // Torneios <-> EtapasPartida (1 para N)
 // A tabela 'etapas_partida' tem 'torneio_id'
 if (models.Torneios && models.EtapasPartida) {
-  models.Torneios.hasMany(models.EtapasPartida, { foreignKey: 'torneio_id', as: 'etapas' });
-  models.EtapasPartida.belongsTo(models.Torneios, { foreignKey: 'torneio_id', as: 'torneio' });
+  models.Torneios.hasMany(models.EtapasPartida, {
+    foreignKey: "torneio_id",
+    as: "etapas",
+  });
+  models.EtapasPartida.belongsTo(models.Torneios, {
+    foreignKey: "torneio_id",
+    as: "torneio",
+  });
 }
 
 // Torneios <-> Participantes (1 para N)
 // A tabela 'participantes' tem 'torneio_id'
 if (models.Participantes && models.Torneios) {
-  models.Torneios.hasMany(models.Participantes, { foreignKey: 'torneio_id', as: 'participantes' });
-  models.Participantes.belongsTo(models.Torneios, { foreignKey: 'torneio_id', as: 'torneio' });
+  models.Torneios.hasMany(models.Participantes, {
+    foreignKey: "torneio_id",
+    as: "participantes",
+  });
+  models.Participantes.belongsTo(models.Torneios, {
+    foreignKey: "torneio_id",
+    as: "torneio",
+  });
 }
 
 // --- Associações de Participantes ---
@@ -109,82 +154,151 @@ if (models.Participantes && models.Torneios) {
 // Participantes <-> Usuarios (1 para 1, opcional)
 // A tabela 'participantes' tem 'usuario_id'
 if (models.Participantes && models.Usuarios) {
-  models.Participantes.belongsTo(models.Usuarios, { foreignKey: 'usuario_id', as: 'usuario' });
-  models.Usuarios.hasOne(models.Participantes, { foreignKey: 'usuario_id', as: 'participacao_torneio' });
+  models.Participantes.belongsTo(models.Usuarios, {
+    foreignKey: "usuario_id",
+    as: "usuario",
+  });
+  models.Usuarios.hasOne(models.Participantes, {
+    foreignKey: "usuario_id",
+    as: "participacao_torneio",
+  });
 }
 
 // Participantes <-> Equipes (1 para 1, opcional)
 // A tabela 'participantes' tem 'equipe_id'
 if (models.Participantes && models.Equipes) {
-  models.Participantes.belongsTo(models.Equipes, { foreignKey: 'equipe_id', as: 'equipe' });
-  models.Equipes.hasOne(models.Participantes, { foreignKey: 'equipe_id', as: 'participacao_torneio' });
+  models.Participantes.belongsTo(models.Equipes, {
+    foreignKey: "equipe_id",
+    as: "equipe",
+  });
+  models.Equipes.hasOne(models.Participantes, {
+    foreignKey: "equipe_id",
+    as: "participacao_torneio",
+  });
 }
-
 
 // --- Associações de Partidas e Chaveamentos ---
 
 // EtapasPartida <-> Partidas (1 para N)
 // A tabela 'partidas' tem 'etapa_id'
 if (models.Partidas && models.EtapasPartida) {
-    models.EtapasPartida.hasMany(models.Partidas, { foreignKey: 'etapa_id', as: 'partidas' });
-    models.Partidas.belongsTo(models.EtapasPartida, { foreignKey: 'etapa_id', as: 'etapa' });
+  models.EtapasPartida.hasMany(models.Partidas, {
+    foreignKey: "etapa_id",
+    as: "partidas",
+  });
+  models.Partidas.belongsTo(models.EtapasPartida, {
+    foreignKey: "etapa_id",
+    as: "etapa",
+  });
 }
 
 // Partidas <-> Chaveamentos (1 para N)
 // A tabela 'chaveamentos' tem 'partida_id'
 if (models.Chaveamentos && models.Partidas) {
-  models.Partidas.hasMany(models.Chaveamentos, { foreignKey: 'partida_id', as: 'chaveamentos' });
-  models.Chaveamentos.belongsTo(models.Partidas, { foreignKey: 'partida_id', as: 'partida' });
+  models.Partidas.hasMany(models.Chaveamentos, {
+    foreignKey: "partida_id",
+    as: "chaveamentos",
+  });
+  models.Chaveamentos.belongsTo(models.Partidas, {
+    foreignKey: "partida_id",
+    as: "partida",
+  });
 }
 
 // Chaveamentos <-> Participantes (Múltiplas N para 1)
 // 'chaveamentos' tem 'participante_a_id', 'participante_b_id', e 'vencedor_id'
 if (models.Chaveamentos && models.Participantes) {
   // Um Chaveamento pertence a um Participante (A, B e Vencedor)
-  models.Chaveamentos.belongsTo(models.Participantes, { foreignKey: 'participante_a_id', as: 'participante_a' });
-  models.Chaveamentos.belongsTo(models.Participantes, { foreignKey: 'participante_b_id', as: 'participante_b' });
-  models.Chaveamentos.belongsTo(models.Participantes, { foreignKey: 'vencedor_id', as: 'vencedor' });
+  models.Chaveamentos.belongsTo(models.Participantes, {
+    foreignKey: "participante_a_id",
+    as: "participante_a",
+  });
+  models.Chaveamentos.belongsTo(models.Participantes, {
+    foreignKey: "participante_b_id",
+    as: "participante_b",
+  });
+  models.Chaveamentos.belongsTo(models.Participantes, {
+    foreignKey: "vencedor_id",
+    as: "vencedor",
+  });
 
   // Um Participante pode estar em muitos Chaveamentos
-  models.Participantes.hasMany(models.Chaveamentos, { foreignKey: 'participante_a_id', as: 'jogos_como_participante_a' });
-  models.Participantes.hasMany(models.Chaveamentos, { foreignKey: 'participante_b_id', as: 'jogos_como_participante_b' });
-  models.Participantes.hasMany(models.Chaveamentos, { foreignKey: 'vencedor_id', as: 'jogos_vencidos' });
+  models.Participantes.hasMany(models.Chaveamentos, {
+    foreignKey: "participante_a_id",
+    as: "jogos_como_participante_a",
+  });
+  models.Participantes.hasMany(models.Chaveamentos, {
+    foreignKey: "participante_b_id",
+    as: "jogos_como_participante_b",
+  });
+  models.Participantes.hasMany(models.Chaveamentos, {
+    foreignKey: "vencedor_id",
+    as: "jogos_vencidos",
+  });
 }
-
 
 // --- Associações de Logs e Pontos ---
 
 // Partidas <-> LogsPartida (1 para N)
 // A tabela 'logs_partida' tem 'partida_id'
 if (models.Partidas && models.LogsPartida) {
-  models.Partidas.hasMany(models.LogsPartida, { foreignKey: 'partida_id', as: 'logs' });
-  models.LogsPartida.belongsTo(models.Partidas, { foreignKey: 'partida_id', as: 'partida' });
+  models.Partidas.hasMany(models.LogsPartida, {
+    foreignKey: "partida_id",
+    as: "logs",
+  });
+  models.LogsPartida.belongsTo(models.Partidas, {
+    foreignKey: "partida_id",
+    as: "partida",
+  });
 }
 
 // LogsPartida <-> Usuarios (Múltiplas N para 1)
 // A tabela 'logs_partida' tem 'usuario_origem_id' e 'usuario_destino_id'
 if (models.Usuarios && models.LogsPartida) {
-  models.LogsPartida.belongsTo(models.Usuarios, { foreignKey: 'usuario_origem_id', as: 'usuario_origem' });
-  models.LogsPartida.belongsTo(models.Usuarios, { foreignKey: 'usuario_destino_id', as: 'usuario_destino' });
+  models.LogsPartida.belongsTo(models.Usuarios, {
+    foreignKey: "usuario_origem_id",
+    as: "usuario_origem",
+  });
+  models.LogsPartida.belongsTo(models.Usuarios, {
+    foreignKey: "usuario_destino_id",
+    as: "usuario_destino",
+  });
 
-  models.Usuarios.hasMany(models.LogsPartida, { foreignKey: 'usuario_origem_id', as: 'logs_enviados' });
-  models.Usuarios.hasMany(models.LogsPartida, { foreignKey: 'usuario_destino_id', as: 'logs_recebidos' });
+  models.Usuarios.hasMany(models.LogsPartida, {
+    foreignKey: "usuario_origem_id",
+    as: "logs_enviados",
+  });
+  models.Usuarios.hasMany(models.LogsPartida, {
+    foreignKey: "usuario_destino_id",
+    as: "logs_recebidos",
+  });
 }
 
 // SaldoPontos <-> Usuarios (N para 1)
 // A tabela 'saldo_pontos' tem 'usuario_id'
 if (models.SaldoPontos && models.Usuarios) {
-  models.Usuarios.hasMany(models.SaldoPontos, { foreignKey: 'usuario_id', as: 'saldos_pontos' });
-  models.SaldoPontos.belongsTo(models.Usuarios, { foreignKey: 'usuario_id', as: 'usuario' });
+  models.Usuarios.hasMany(models.SaldoPontos, {
+    foreignKey: "usuario_id",
+    as: "saldos_pontos",
+  });
+  models.SaldoPontos.belongsTo(models.Usuarios, {
+    foreignKey: "usuario_id",
+    as: "usuario",
+  });
 }
 
 // SaldoPontos <-> Jogos (N para 1)
 // A tabela 'saldo_pontos' tem 'jogo_id'
 if (models.SaldoPontos && models.Jogos) {
-  models.Jogos.hasMany(models.SaldoPontos, { foreignKey: 'jogo_id', as: 'saldos_pontos_jogo' });
-  models.SaldoPontos.belongsTo(models.Jogos, { foreignKey: 'jogo_id', as: 'jogo' });
+  models.Jogos.hasMany(models.SaldoPontos, {
+    foreignKey: "jogo_id",
+    as: "saldos_pontos_jogo",
+  });
+  models.SaldoPontos.belongsTo(models.Jogos, {
+    foreignKey: "jogo_id",
+    as: "jogo",
+  });
 }
-
 
 // Exporta os models com as associações configuradas
 export default models;

--- a/src/backend/glitch_api/src/models/pessoas/membrosEquipe.model.ts
+++ b/src/backend/glitch_api/src/models/pessoas/membrosEquipe.model.ts
@@ -1,83 +1,97 @@
 import { DataTypes, Model, Optional } from "sequelize";
-import {sequelize} from '../../config/database.config';
-import models from "../index.models";
+import { sequelize } from "../../config/database.config";
 import Equipes from "./equipes.model";
 import { Usuarios } from "./index.pessoas";
 
-export interface MembrosEquipeAtributos{
-    equipe_id:string;
-    usuario_id:string;
-    funcao:string;
-    is_lider:boolean;
-    is_titular:boolean;
-    is_ativo:boolean;
-    dt_convite:Date;
-    dt_aceito?:Date|null;
-    dt_saida?:Date|null;
+export interface MembrosEquipeAtributos {
+  equipe_id: string;
+  usuario_id: string;
+  funcao: string;
+  is_lider: boolean;
+  is_titular: boolean;
+  is_ativo: boolean;
+  dt_convite: Date;
+  dt_aceito?: Date | null;
+  dt_saida?: Date | null;
+  tipo: "convite" | "solicitacao";
 }
 
-export interface MembrosEquipeAtributosCriacao extends Optional<MembrosEquipeAtributos,'funcao'|'dt_aceito'|'dt_saida'>{};
+export interface MembrosEquipeAtributosCriacao extends Optional<
+  MembrosEquipeAtributos,
+  "funcao" | "dt_aceito" | "dt_saida" | "tipo"
+> {}
 
-export class MembrosEquipe extends Model<MembrosEquipeAtributos,MembrosEquipeAtributosCriacao>{};
+export class MembrosEquipe extends Model<
+  MembrosEquipeAtributos,
+  MembrosEquipeAtributosCriacao
+> {}
 
-MembrosEquipe.init({
-    equipe_id:{
-        type:DataTypes.UUID,
-        allowNull:false,
-        references:{
-            model:Equipes,
-            key:'id'
-        },
-        onDelete:'RESTRICT',
-        onUpdate:'CASCADE'
+MembrosEquipe.init(
+  {
+    equipe_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: Equipes,
+        key: "id",
+      },
+      onDelete: "RESTRICT",
+      onUpdate: "CASCADE",
     },
-    usuario_id:{
-        type:DataTypes.UUID,
-        allowNull:false,
-        references:{
-            model:Usuarios,
-            key:'id'
-        },
-        onDelete:'RESTRICT',
-        onUpdate:'CASCADE'
+    usuario_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: Usuarios,
+        key: "id",
+      },
+      onDelete: "RESTRICT",
+      onUpdate: "CASCADE",
     },
-    funcao:{
-        type:DataTypes.STRING(20),
-        allowNull:true,
+    funcao: {
+      type: DataTypes.STRING(20),
+      allowNull: true,
     },
-    is_lider:{
-        type:DataTypes.BOOLEAN,
-        allowNull:false,
-        defaultValue:false,
+    is_lider: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
-    is_titular:{
-        type:DataTypes.BOOLEAN,
-        allowNull:false,
-        defaultValue:true,
+    is_titular: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
-    is_ativo:{
-        type:DataTypes.BOOLEAN,
-        allowNull:false,
-        defaultValue:true,
+    is_ativo: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
-    dt_convite:{
-        type:DataTypes.DATE,
-        allowNull:false,
-        defaultValue:DataTypes.NOW,
+    dt_convite: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     },
-    dt_aceito:{
-        type:DataTypes.DATE,
-        allowNull:true,
+    dt_aceito: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
-    dt_saida:{
-        type:DataTypes.DATE,
-        allowNull:true,
-    }
-},{
+    dt_saida: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    tipo: {
+      type: DataTypes.ENUM("convite", "solicitacao"),
+      allowNull: false,
+      defaultValue: "convite",
+    },
+  },
+  {
     sequelize,
-    tableName:'membros_equipe',
-    timestamps:false,
-    underscored:true,
-})
+    tableName: "membros_equipe",
+    timestamps: false,
+    underscored: true,
+  },
+);
 
 export default MembrosEquipe;

--- a/src/backend/glitch_api/src/services/equipe.service.ts
+++ b/src/backend/glitch_api/src/services/equipe.service.ts
@@ -3,28 +3,35 @@ import models from "../models/index.models";
 import { Op } from "sequelize";
 
 class UsuarioService {
-    public async addEquipe(nome: string, lider: string): Promise<any> {
-        let transaction = await sequelize.transaction()
-        try {
-            let equipe = await models.Equipes.create({
-                nome: nome, dt_criacao: new Date()
-            }, { transaction })
-            let membro = await models.MembrosEquipe.create({
-                equipe_id: equipe.dataValues.id,
-                usuario_id: lider,
-                is_ativo: true,
-                is_lider: true,
-                is_titular: true,
-                dt_convite: new Date(),
-                dt_aceito: new Date()
-            }, { transaction })
-            transaction.commit()
-            return equipe;
-        } catch (e) {
-            transaction.rollback()
-            throw e;
-        }
+  public async addEquipe(nome: string, lider: string): Promise<any> {
+    let transaction = await sequelize.transaction();
+    try {
+      let equipe = await models.Equipes.create(
+        {
+          nome: nome,
+          dt_criacao: new Date(),
+        },
+        { transaction },
+      );
+      let membro = await models.MembrosEquipe.create(
+        {
+          equipe_id: equipe.dataValues.id,
+          usuario_id: lider,
+          is_ativo: true,
+          is_lider: true,
+          is_titular: true,
+          dt_convite: new Date(),
+          dt_aceito: new Date(),
+        },
+        { transaction },
+      );
+      transaction.commit();
+      return equipe;
+    } catch (e) {
+      transaction.rollback();
+      throw e;
     }
+  }
 
   public async convidarJogador(
     equipe_id: string,
@@ -34,6 +41,7 @@ class UsuarioService {
       is_lider: boolean;
       funcao: string;
     },
+    tipo: "convite" | "solicitacao" = "convite",
   ): Promise<any> {
     let transaction = await sequelize.transaction();
     try {
@@ -61,14 +69,16 @@ class UsuarioService {
         transaction,
       });
 
+      const isAtivo = false;
       if (membroExistente) {
         await membroExistente.update(
           {
-            is_ativo: true,
+            is_ativo: isAtivo,
             is_lider: convidado.is_lider,
             is_titular: convidado.is_titular,
-            funcao: "",
+            funcao: convidado.funcao,
             dt_convite: new Date(),
+            tipo,
           },
           { transaction },
         );
@@ -77,11 +87,12 @@ class UsuarioService {
           {
             equipe_id: equipe.dataValues.id,
             usuario_id: jogador.dataValues.id,
-            is_ativo: true,
+            is_ativo: isAtivo,
             is_lider: convidado.is_lider,
             is_titular: convidado.is_titular,
             dt_convite: new Date(),
             funcao: convidado.funcao,
+            tipo,
           },
           { transaction },
         );
@@ -94,249 +105,366 @@ class UsuarioService {
     }
   }
 
-    public async getMinhasEquipes(usuario_id: string): Promise<any> {
-        try {
-            let equipes = await models.Equipes.findAll({
-                attributes: [
-                    'id',
-                    'nome',
-                    'dt_criacao',
-                ],
-                include: [{
-                    model: models.MembrosEquipe,
-                    as: 'associacoesMembro',
-                    attributes: ['is_lider', 'is_titular'],
-                    where: { is_ativo: true, dt_aceito: {[Op.not]: null}, dt_saida: null, usuario_id },
-                    include: [{
-                        model: models.Usuarios,
-                        as: 'membro',
-                    }]
-                },],
-                where:{is_ativo:true},
-            })
-            return equipes
-        } catch (e) {
-            throw e;
-        }
+  public async getMinhasEquipes(usuario_id: string): Promise<any> {
+    try {
+      let equipes = await models.Equipes.findAll({
+        attributes: ["id", "nome", "dt_criacao"],
+        include: [
+          {
+            model: models.MembrosEquipe,
+            as: "associacoesMembro",
+            attributes: [
+              "funcao",
+              "is_lider",
+              "is_titular",
+              "dt_aceito",
+              "tipo",
+            ],
+            where: {
+              is_ativo: true,
+              dt_aceito: { [Op.not]: null },
+              dt_saida: null,
+              usuario_id,
+              is_titular: true,
+            },
+            include: [
+              {
+                model: models.Usuarios,
+                as: "membro",
+              },
+            ],
+          },
+        ],
+        where: { is_ativo: true },
+      });
+      return equipes;
+    } catch (e) {
+      throw e;
     }
+  }
 
-    public async getEquipes(): Promise<any> {
-        try {
-            let resposta = await models.Equipes.findAll({
-                attributes: ['id', 'nome'],
-                where:{is_ativo:true},
-                include: [{
-                    model: models.Usuarios,
-                    as: 'membros', // O 'as' da sua associação Equipes -> Usuarios
-                    attributes: ['nickname'],
-                    through: {
-                        // 'through' permite acessar o modelo MembrosEquipe
-                        attributes: ['funcao', 'is_lider', 'is_titular'],
-                        where: {
-                            // Aplicando seu 'where' diretamente na tabela 'through'
-                            is_ativo: true,
-                           // dt_aceito: {    [Op.not]: null },  --> comentada pois bloqueava o cálculo de quantidade de integrantes
-                            dt_saida: {
-                                [Op.is]: null
-                            }
-                        }
-                    }
-                }]
-            });
-            return resposta
-        } catch (e) {
-            throw e;
-        }
-    }
-
-    public async getEquipePorId(id: string): Promise<any> {
-        try {
-            let resposta = await models.Equipes.findByPk(id, {
-                attributes: ['id', 'nome'],
-                include: [{
-                    model: models.Usuarios,
-                    as: 'membros', // O 'as' da sua associação Equipes -> Usuarios
-                    attributes: ['nickname'],
-                    through: {
-                        // 'through' permite acessar o modelo MembrosEquipe
-                        attributes: ['funcao', 'is_lider', 'is_titular','dt_aceito'],
-                        where: {
-                            // Aplicando seu 'where' diretamente na tabela 'through'
-                            is_ativo: true,
-                            dt_saida: {
-                                [Op.is]: null
-                            }
-                        }
-                    }
-                }]
-            });
-
-            if(!resposta){
-                throw new Error("Equipe não encontrada")
-            }
-
-            let equipe:any = resposta.toJSON()
-            equipe.membros = equipe.membros.map((membro:any)=>{
-                return {
-                    nickname:membro.nickname,
-                    ...membro.MembrosEquipe
-                }
-            })
-
-            return equipe
-        } catch (e) {
-            throw e;
-        }
-    }
-
-    public async getInvites(usuario_id: string): Promise<any> {
-        try {
-            let invites = await models.Equipes.findAll({
-                attributes: ['id', 'nome'],
-                where:{is_ativo:true},
-                include: [{
-                    model: models.MembrosEquipe,
-                    as: 'associacoesMembro',
-                    where: [{
-                        dt_aceito: { [Op.is]: null },
-                        dt_saida: { [Op.is]: null },
-                        usuario_id
-                    }]
-                }]
-            })
-            return invites
-        } catch (e) {
-            throw e;
-        }
-    }
-
-    public async answerInvite(usuario: string, equipe: string, resposta: boolean) {
-        let transaction = await sequelize.transaction();
-        try {
-            let convite = await models.MembrosEquipe.findOne({
-                where: {
-                    usuario_id: usuario,
-                    equipe_id: equipe,
-                    dt_aceito: null,
-                    dt_saida: null
+  public async getEquipes(): Promise<any> {
+    try {
+      let resposta = await models.Equipes.findAll({
+        attributes: ["id", "nome"],
+        where: { is_ativo: true },
+        include: [
+          {
+            model: models.Usuarios,
+            as: "membros", 
+            attributes: ["nickname"],
+            through: {
+              attributes: ["funcao", "is_lider", "is_titular", "is_ativo"],
+              where: {
+                is_ativo: true,
+                dt_saida: {
+                  [Op.is]: null,
                 },
-                transaction
-            })
-            if (!convite) {
-                throw new Error("Convite não encontrado ou já respondido");
-            }
-            if (resposta) {
-                //Aceito
-                await convite.update({
-                    dt_aceito: new Date()
-                }, { transaction })
-            } else {
-                //Recusado
-                await convite.update({
-                    dt_saida: new Date()
-                }, { transaction })
-            }
-            await transaction.commit()
-            return 200;
-        } catch (e) {
-            await transaction.rollback()
-            throw e
-        }
+              },
+            },
+          },
+        ],
+      });
+      return resposta;
+    } catch (e) {
+      throw e;
     }
+  }
 
-    async updateEquipe(id: string, novo_nome: string): Promise<any> {
-        let transaction = await sequelize.transaction()
-        try {
-            let possivel_equipe = await models.Equipes.findOne({ where: { nome: novo_nome } })
-            if (possivel_equipe) {
-                throw new Error('Já existe uma equipe com esse nome');
-            }
-            let equipe = await models.Equipes.findByPk(id)
-            if (!equipe) {
-                throw new Error('Equipe não encontrada');
-            }
-            await equipe.update({ nome: novo_nome }, { transaction })
-            await transaction.commit()
-            return '200'
-        } catch (e) {
-            await transaction.rollback()
-            throw e;
-        }
+  public async getEquipePorId(id: string): Promise<any> {
+    try {
+      let resposta = await models.Equipes.findByPk(id, {
+        attributes: ["id", "nome"],
+        include: [
+          {
+            model: models.Usuarios,
+            as: "membros", 
+            attributes: ["nickname"],
+            through: {
+            
+              attributes: [
+                "funcao",
+                "is_lider",
+                "is_titular",
+                "is_ativo",
+                "dt_aceito",
+              ],
+              where: {
+                is_ativo: true,
+                dt_saida: {
+                  [Op.is]: null,
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      if (!resposta) {
+        throw new Error("Equipe não encontrada");
+      }
+
+      let equipe: any = resposta.toJSON();
+      equipe.membros = equipe.membros.map((membro: any) => {
+        return {
+          nickname: membro.nickname,
+          ...membro.MembrosEquipe,
+        };
+      });
+
+      return equipe;
+    } catch (e) {
+      throw e;
     }
+  }
 
-    async updateMembro(membro: any,equipe:string): Promise<any> {
-        let transaction = await sequelize.transaction()
-        try {
-            let usuario = await models.Usuarios.findOne({where:{nickname:membro.nickname}})
-            let membroEquipe = await models.MembrosEquipe.findOne({ where: { usuario_id: usuario?.dataValues.id, equipe_id: equipe} })
-            if (!membroEquipe) {
-                throw new Error('Membro da equipe não encontrado');
-            }
-            await membroEquipe.update({ is_titular: membro.is_titular, is_lider: membro.is_lider, funcao: membro.funcao }, { transaction })
-            await transaction.commit()
-            return '200'
-        } catch (e) {
-            await transaction.rollback()
-            console.error(e)
-            throw e;
-        }
+  public async getInvites(usuario_id: string): Promise<any> {
+    try {
+      let invites = await models.Equipes.findAll({
+        attributes: ["id", "nome"],
+        where: { is_ativo: true },
+        include: [
+          // Garante que EU sou líder da equipe
+          {
+            model: models.MembrosEquipe,
+            as: "membrosAtivos",
+            attributes: ["usuario_id", "is_lider"],
+            required: false,
+            where: {
+              usuario_id,
+              is_lider: true,
+              dt_saida: null,
+              dt_aceito: { [Op.not]: null },
+            },
+          },
+
+          //Busca os convites pendentes da equipe
+          {
+            model: models.MembrosEquipe,
+            as: "associacoesMembro",
+            attributes: [
+              "funcao",
+              "is_lider",
+              "is_titular",
+              "dt_aceito",
+              "tipo",
+              "usuario_id",
+            ],
+            where: {
+              dt_aceito: { [Op.is]: null },
+              dt_saida: { [Op.is]: null },
+            },
+            include: [
+              {
+                model: models.Usuarios,
+                as: "membro",
+                attributes: ["nickname"],
+              },
+            ],
+          },
+        ],
+      });
+
+      //Filtro de situações:
+      invites = invites
+        .map((equipe: any) => {
+          const souLider = (equipe.membrosAtivos?.length ?? 0) > 0;
+
+          equipe.associacoesMembro = equipe.associacoesMembro.filter(
+            (m: any) => {
+              //Convites para mim
+              if (m.tipo === "convite" && m.usuario_id === usuario_id) {
+                return true;
+              }
+
+              //Solicitações para entrar na minha equipe
+              if (m.tipo === "solicitacao" && souLider) {
+                return true;
+              }
+              return false;
+            },
+          );
+          return equipe;
+        })
+        .filter((equipe: any) => equipe.associacoesMembro.length > 0);
+      return invites;
+    } catch (e) {
+      console.log(e);
+      throw e;
     }
+  }
 
-    async removeEquipe(id: string): Promise<any> {
-        const transaction = await sequelize.transaction();
-        try {
-            const equipe = await models.Equipes.findByPk(id, {
-                transaction,
-                attributes: ['id']
-            });
-
-            if (!equipe) {
-                await transaction.rollback();
-                throw new Error('Equipe não encontrada');
-            }
-            await Promise.all([
-                // Atualiza TODOS os membros com uma única query SQL eficiente
-                models.MembrosEquipe.update(
-                    { is_ativo: false },
-                    { where: { equipe_id: id }, transaction }
-                ),
-                // Atualiza a equipe. 
-                models.Equipes.update(
-                    { is_ativo: false },
-                    { where: { id: id }, transaction }
-                )
-            ]);
-
-            // Passo 3: Efetivação
-            await transaction.commit();
-            return { success: true, message: 'Equipe e membros removidos com sucesso' };
-
-        } catch (e) {
-            await transaction.rollback();
-            console.error("Erro ao remover equipe:", e);
-            throw e;
-        }
+  public async answerInvite(
+    usuarioLogado: string,
+    equipe: string,
+    usuarioAlvo: string,
+    resposta: boolean,
+  ) {
+    let transaction = await sequelize.transaction();
+    try {
+      let convite = await models.MembrosEquipe.findOne({
+        where: {
+          equipe_id: equipe,
+          usuario_id: usuarioAlvo,
+          dt_aceito: null,
+          dt_saida: null,
+        },
+        transaction,
+      });
+      if (!convite) {
+        throw new Error("Convite não encontrado ou já respondido");
+      }
+      if (resposta) {
+        //Aceito
+        await convite.update(
+          {
+            dt_aceito: new Date(),
+            is_ativo: true,
+          },
+          { transaction },
+        );
+      } else {
+        //Recusado
+        await convite.update(
+          {
+            dt_saida: new Date(),
+          },
+          { transaction },
+        );
+      }
+      await transaction.commit();
+      return 200;
+    } catch (e) {
+      await transaction.rollback();
+      throw e;
     }
+  }
 
-    async removeMembro(nickname: string,equipe:string): Promise<any> {
-        let transaction = await sequelize.transaction()
-        try {
-            let usuario = await models.Usuarios.findOne({where:{nickname}})
-            let membroEquipe = await models.MembrosEquipe.findOne({where:{equipe_id:equipe,usuario_id:usuario?.dataValues.id},transaction})
-            if(!membroEquipe){
-                await transaction.rollback()
-                throw new Error('Membro da equipe não encontrada');
-            }
-            await membroEquipe.update({is_ativo:false})
-            await transaction.commit()
-            return '200'
-        } catch (e) {
-            await transaction.rollback();
-            console.error("Erro ao remover equipe:", e);
-            throw e;
-        }
+  async updateEquipe(id: string, novo_nome: string): Promise<any> {
+    let transaction = await sequelize.transaction();
+    try {
+      let possivel_equipe = await models.Equipes.findOne({
+        where: { nome: novo_nome },
+      });
+      if (possivel_equipe) {
+        throw new Error("Já existe uma equipe com esse nome");
+      }
+      let equipe = await models.Equipes.findByPk(id);
+      if (!equipe) {
+        throw new Error("Equipe não encontrada");
+      }
+      await equipe.update({ nome: novo_nome }, { transaction });
+      await transaction.commit();
+      return "200";
+    } catch (e) {
+      await transaction.rollback();
+      throw e;
     }
+  }
 
+  async updateMembro(membro: any, equipe: string): Promise<any> {
+    let transaction = await sequelize.transaction();
+    try {
+      let usuario = await models.Usuarios.findOne({
+        where: { nickname: membro.nickname },
+      });
+      let membroEquipe = await models.MembrosEquipe.findOne({
+        where: { usuario_id: usuario?.dataValues.id, equipe_id: equipe },
+      });
+      if (!membroEquipe) {
+        throw new Error("Membro da equipe não encontrado");
+      }
+      await membroEquipe.update(
+        {
+          is_titular: membro.is_titular,
+          is_lider: membro.is_lider,
+          funcao: membro.funcao,
+        },
+        { transaction },
+      );
+      await transaction.commit();
+      return "200";
+    } catch (e) {
+      await transaction.rollback();
+      console.error(e);
+      throw e;
+    }
+  }
+
+  async removeEquipe(id: string): Promise<any> {
+    const transaction = await sequelize.transaction();
+    try {
+      const equipe = await models.Equipes.findByPk(id, {
+        transaction,
+        attributes: ["id"],
+      });
+
+      if (!equipe) {
+        await transaction.rollback();
+        throw new Error("Equipe não encontrada");
+      }
+      await Promise.all([
+        models.MembrosEquipe.update(
+          { is_ativo: false },
+          { where: { equipe_id: id }, transaction },
+        ),
+        // Atualiza a equipe
+        models.Equipes.update(
+          { is_ativo: false },
+          { where: { id: id }, transaction },
+        ),
+      ]);
+
+      await transaction.commit();
+      return {
+        success: true,
+        message: "Equipe e membros removidos com sucesso",
+      };
+    } catch (e) {
+      await transaction.rollback();
+      console.error("Erro ao remover equipe:", e);
+      throw e;
+    }
+  }
+
+  async removeMembro(nickname: string, equipe: string): Promise<any> {
+    let transaction = await sequelize.transaction();
+    try {
+      let usuario = await models.Usuarios.findOne({ where: { nickname } });
+      let membroEquipe = await models.MembrosEquipe.findOne({
+        where: { equipe_id: equipe, usuario_id: usuario?.dataValues.id },
+        transaction,
+      });
+      if (!membroEquipe) {
+        await transaction.rollback();
+        throw new Error("Membro da equipe não encontrada");
+      }
+      await membroEquipe.update({ is_ativo: false });
+      await transaction.commit();
+      return "200";
+    } catch (e) {
+      await transaction.rollback();
+      console.error("Erro ao remover equipe:", e);
+      throw e;
+    }
+  }
+
+  public async verificarSeLider(
+    usuario_id: string,
+    equipe_id: string,
+  ): Promise<boolean> {
+    const membro = await models.MembrosEquipe.findOne({
+      where: {
+        usuario_id,
+        equipe_id,
+        is_lider: true,
+        is_ativo: true,
+        dt_aceito: { [Op.not]: null },
+        dt_saida: { [Op.is]: null },
+      },
+    });
+    return !!membro;
+  }
 }
 
 export default new UsuarioService();

--- a/src/frontend/glitch_frontend/src/app/components/button/button.scss
+++ b/src/frontend/glitch_frontend/src/app/components/button/button.scss
@@ -45,7 +45,7 @@
   }
 
   &:disabled {
-    background-color: #ccc;
+    background-color: #838282;
     cursor: not-allowed;
   }
 }
@@ -108,7 +108,5 @@
 
 .warn {
   background-color: var(--secundary-color-base);
-  &:hover {
-    background-color: var(--secundary-color-dark);
-  }
+ 
 }

--- a/src/frontend/glitch_frontend/src/app/components/team-invite-box-component/team-invite-box-component.html
+++ b/src/frontend/glitch_frontend/src/app/components/team-invite-box-component/team-invite-box-component.html
@@ -1,42 +1,73 @@
-<h3><mat-icon>groups</mat-icon>Convites de Equipe</h3>
+<h3><mat-icon>groups</mat-icon>Convites Recebidos:</h3>
 
 <ul class="invite-list">
-  @if (convites$ | async; as convites) {
-    @if (convites.length === 0) {
-      <!--- MOCK TEMPORÁRIO ATÉ CONSEGUIRMOS TESTAR COM CONVITES REAIS-->
-      <p class="empty">Você não tem convites de equipe pendentes.</p>
+  @if (convitesRecebidos.length === 0) {
+    <p class="empty">Você não tem convites pendentes.</p>
+  } @else {
+    @for (membro of convitesRecebidos; track membro.usuario_id) {
+      <li class="invite-item">
+        <span class="team-name">
+          {{ membro.equipeNome }} - {{ membro.membro.nickname }}
+        </span>
 
+        <div class="invite-actions">
+          <app-button
+            label="Aceitar"
+            icon="check"
+            color="accent"
+            size="small"
+            (click)="aceitarConvite(membro.equipeId, membro.usuario_id)"
+          ></app-button>
+
+          <app-button
+            label="Recusar"
+            icon="close"
+            color="refuse"
+            size="small"
+            (click)="recusarConvite(membro.equipeId, membro.usuario_id)"
+          ></app-button>
+        </div>
+      </li>
+    }
+  }
+</ul>
+
+<!-- Se eu for líder mostrar as solicitações de entrada recebidas -->
+
+@if (solicitacoesPendentes.length > 0) {
+  <h3 style="margin-top: 5%">
+    <mat-icon>groups</mat-icon>Solicitações de entrada:
+  </h3>
+
+  <ul class="invite-list">
+    @if (solicitacoesPendentes.length === 0) {
+      <p class="empty">Você não tem solicitações pendentes.</p>
     } @else {
-      <!--- DADOS REAIS -->
-      @for (equipe of convites; track equipe.id) {
+      @for (membro of solicitacoesPendentes; track membro.usuario_id) {
         <li class="invite-item">
-          <span class="team-name">{{ equipe.nome }}</span>
+          <span class="team-name">
+            {{ membro.equipeNome }} - {{ membro.membro.nickname }}
+          </span>
 
           <div class="invite-actions">
             <app-button
               label="Aceitar"
               icon="check"
-              iconPosition="left"
               color="accent"
               size="small"
-              (click)="aceitarConvite(equipe.id)"
-            >
-            </app-button>
+              (click)="aceitarConvite(membro.equipeId, membro.usuario_id)"
+            ></app-button>
+
             <app-button
               label="Recusar"
               icon="close"
-              iconPosition="left"
               color="refuse"
               size="small"
-              (click)="recusarConvite(equipe.id)"
-            >
-            </app-button>
+              (click)="recusarConvite(membro.equipeId, membro.usuario_id)"
+            ></app-button>
           </div>
         </li>
       }
     }
-    <!-- @else {
-      <p>Nenhum convite</p>
-    } -->
-  }
-</ul>
+  </ul>
+}

--- a/src/frontend/glitch_frontend/src/app/components/team-invite-box-component/team-invite-box-component.ts
+++ b/src/frontend/glitch_frontend/src/app/components/team-invite-box-component/team-invite-box-component.ts
@@ -18,13 +18,6 @@ export class TeamInviteBoxComponent implements OnInit {
     return 'team-invite-box';
   }
 
-  // Você pode popular isso via um Input() ou buscando de um serviço
-  convites = [
-    { id: 1, teamName: 'Os Campeões' },
-    { id: 2, teamName: 'Esquadrão Relâmpago' },
-    { id: 3, teamName: 'Pro Players BR' },
-  ];
-
   private readonly convitesSubject = new BehaviorSubject<any[]>([]);
 
   // 3. O Observable (público) que seu componente usará
@@ -32,16 +25,30 @@ export class TeamInviteBoxComponent implements OnInit {
   public readonly convites$: Observable<any[]> =
     this.convitesSubject.asObservable();
 
+  convitesRecebidos: any[] = [];
+  solicitacoesPendentes: any[] = [];
+
   constructor(
     private equipeService: EquipeService,
     private sysNotifService: SystemNotificationService,
   ) {}
 
-  // 5. Método para buscar os dados e ATUALIZAR o Subject
   public carregarConvites(): void {
     this.equipeService.getConvites().subscribe({
-      next: (res) => {
-        this.convitesSubject.next(res);
+      next: (equipes) => {
+        this.convitesSubject.next(equipes);
+
+        this.convitesRecebidos = equipes.flatMap((e: any) =>
+          e.associacoesMembro
+            .filter((m: any) => m.tipo === 'convite')
+            .map((m: any) => ({ ...m, equipeId: e.id, equipeNome: e.nome })),
+        );
+
+        this.solicitacoesPendentes = equipes.flatMap((e: any) =>
+          e.associacoesMembro
+            .filter((m: any) => m.tipo === 'solicitacao')
+            .map((m: any) => ({ ...m, equipeId: e.id, equipeNome: e.nome })),
+        );
       },
     });
   }
@@ -50,31 +57,31 @@ export class TeamInviteBoxComponent implements OnInit {
     this.carregarConvites();
   }
 
- aceitarConvite(id: string) {
-  this.equipeService.aceitarConvite(id).subscribe({
-    next: (res) => {
-      this.sysNotifService.notificar('sucesso', 'Aceito com sucesso');
-      console.log('Convite aceito');
-      this.carregarConvites();
-    },
-    error: (err) => {
-      console.log(err);
-      this.sysNotifService.notificar('erro', 'Erro ao aceitar');
-    },
-  });
-}
+  aceitarConvite(equipeId: string, usuarioAlvo: string) {
+    this.equipeService.aceitarConvite(equipeId, usuarioAlvo).subscribe({
+      next: (res) => {
+        this.sysNotifService.notificar('sucesso', 'Aceito com sucesso');
+        console.log('Convite aceito');
+        this.carregarConvites();
+      },
+      error: (err) => {
+        console.log(err);
+        this.sysNotifService.notificar('erro', 'Erro ao aceitar');
+      },
+    });
+  }
 
-recusarConvite(id: string) {
-  this.equipeService.recusarConvite(id).subscribe({
-    next: (res) => {
-      this.sysNotifService.notificar('sucesso', 'Recusado com sucesso');
-      this.carregarConvites();
-      console.log('Convite recusado');
-    },
-    error: (err) => {
-      console.log(err);
-      this.sysNotifService.notificar('erro', 'Erro ao recusar');
-    },
-  });
-}
+  recusarConvite(equipeId: string, usuarioAlvo: string) {
+    this.equipeService.recusarConvite(equipeId, usuarioAlvo).subscribe({
+      next: (res) => {
+        this.sysNotifService.notificar('sucesso', 'Recusado com sucesso');
+        this.carregarConvites();
+        console.log('Convite recusado');
+      },
+      error: (err) => {
+        console.log(err);
+        this.sysNotifService.notificar('erro', 'Erro ao recusar');
+      },
+    });
+  }
 }

--- a/src/frontend/glitch_frontend/src/app/pages/create-group/create-group.html
+++ b/src/frontend/glitch_frontend/src/app/pages/create-group/create-group.html
@@ -14,64 +14,55 @@
       </div>
 
       <div class="table-wrapper">
-        <div class="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <th>Nome</th>
-                <th>Idade</th>
-                <th>Nacionalidade</th>
-                <th></th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
+        <table>
+          <thead>
+            <tr>
+              <th>Nickname</th>
+              <th>Idade</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            @if (jogadores$ | async; as jogadores) {
               @if (jogadores$ | async; as jogadores) {
-                @if (jogadores$ | async; as jogadores) {
-                  @for (jogador of jogadores; track jogador.nickname) {
-                    <tr>
-                      <td>{{ jogador.nickname }}</td>
-                      <td>{{ jogador.idade }}</td>
-                      <td>{{ jogador.nacionalidade }}</td>
+                @for (jogador of jogadores; track jogador.nickname) {
+                  <tr>
+                    <td>{{ jogador.nickname }}</td>
+                    <td>{{ jogador.idade }}</td>
 
-                      <td>{{ jogador.nickname }}</td>
-                      <td>{{ jogador.idade }}</td>
-                      <td>{{ jogador.nacionalidade }}</td>
-
-                      <td>
-                        <app-button
-                          [label]="
-                            isMobile()
-                              ? ''
-                              : isSelecionado(jogador.nickname)
-                                ? 'Adicionado'
-                                : 'Adicionar'
-                          "
-                          [icon]="
-                            isMobile()
-                              ? isSelecionado(jogador.nickname)
-                                ? 'check'
-                                : 'add'
-                              : isSelecionado(jogador.nickname)
-                                ? 'check'
-                                : 'groupAdd'
-                          "
-                          size="medium"
-                          (click)="toggleConvidado(jogador.nickname)"
-                          [color]="
-                            isSelecionado(jogador.nickname)
-                              ? 'selected'
-                              : 'notSelected'
-                          "
-                        ></app-button>
-                      </td>
-                    </tr>
-                  }
+                    <td>
+                      <app-button
+                        [label]="
+                          isMobile()
+                            ? ''
+                            : isSelecionado(jogador.nickname)
+                              ? 'Adicionado'
+                              : 'Adicionar'
+                        "
+                        [icon]="
+                          isMobile()
+                            ? isSelecionado(jogador.nickname)
+                              ? 'check'
+                              : 'add'
+                            : isSelecionado(jogador.nickname)
+                              ? 'check'
+                              : 'groupAdd'
+                        "
+                        size="medium"
+                        (click)="toggleConvidado(jogador.nickname)"
+                        [color]="
+                          isSelecionado(jogador.nickname)
+                            ? 'selected'
+                            : 'notSelected'
+                        "
+                      ></app-button>
+                    </td>
+                  </tr>
                 }
               }
-            </tbody>
-          </table>
-        </div>
+            }
+          </tbody>
+        </table>
       </div>
 
       <div class="form-row actions-row">

--- a/src/frontend/glitch_frontend/src/app/pages/create-group/create-group.scss
+++ b/src/frontend/glitch_frontend/src/app/pages/create-group/create-group.scss
@@ -24,7 +24,7 @@ app-navigation {
   max-width: 1200px;
 
   h2 {
-    font-family: 'Bebas Neue', sans-serif;
+    font-family: "Bebas Neue", sans-serif;
     font-size: 2rem;
     margin-bottom: 20px;
     text-align: center;
@@ -57,7 +57,7 @@ app-navigation {
   }
 
   .table-wrapper {
-    width: 90%;
+    width: auto;
     max-width: 900px;
     background: rgba(255, 255, 255, 0.05);
     border: 2px solid #67679267;
@@ -67,12 +67,15 @@ app-navigation {
     overflow-y: hidden;
     margin-bottom: 24px;
 
-    &:has(tbody tr:nth-child(n+8)) {
+    &:has(tbody tr:nth-child(n + 8)) {
       overflow-y: auto;
     }
 
     table {
-      width: 100%;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      width: auto;
       border-collapse: collapse;
       word-wrap: normal;
       table-layout: fixed;
@@ -89,7 +92,7 @@ app-navigation {
 
       th {
         background-color: rgba(255, 255, 255, 0.08);
-        font-family: 'Bebas Neue', sans-serif;
+        font-family: "Bebas Neue", sans-serif;
         font-size: 1.1rem;
         letter-spacing: 1px;
       }

--- a/src/frontend/glitch_frontend/src/app/pages/list-group/list-group.html
+++ b/src/frontend/glitch_frontend/src/app/pages/list-group/list-group.html
@@ -1,4 +1,3 @@
-
 <div class="list-group-container">
   <h2>Listar equipes</h2>
   <app-button
@@ -41,14 +40,16 @@
                         (click)="irParaEdicao(dados.id)"
                         title="Editar"
                       ></app-button>
-                      <app-button
-                        label=""
-                        icon="delete"
-                        size="medium"
-                        color="refuse"
-                        (clicked)="excluirEquipe(dados.id)"
-                        title="Remover"
-                      ></app-button>
+                      @if (isLiderDaEquipe(dados)) {
+                        <app-button
+                          label=""
+                          icon="delete"
+                          size="medium"
+                          color="refuse"
+                          (clicked)="excluirEquipe(dados.id)"
+                          title="Remover"
+                        ></app-button>
+                      }
                     </td>
                   </tr>
                 }
@@ -68,11 +69,11 @@
     <div class="tabela-individual">
       <h3>Outras equipes</h3>
       <div class="table-wrapper">
-        <table class="team-table">
+        <table class="team-table others-teams">
           <thead>
             <tr>
               <th>Nome</th>
-              <th >Qtd Integrantes</th>
+              <th>Qtd Integrantes</th>
               <th class="acoes acoes-maior"></th>
             </tr>
           </thead>
@@ -87,20 +88,32 @@
                     </td>
                     <td class="acoes" data-label="Ação">
                       <app-button
-                        label="Enviar convite"
-                        icon="send"
+                        [label]="
+                          jaTemSolicitacaoPendente(dados)
+                            ? 'Pendente'
+                            : 'Solicitar entrada'
+                        "
+                        [icon]="
+                          jaTemSolicitacaoPendente(dados)
+                            ? 'hourglass_empty'
+                            : 'send'
+                        "
                         size="small"
-                        (click)="enviarConvite()"
+                        [disabled]="jaTemSolicitacaoPendente(dados)"
+                        (click)="
+                          !jaTemSolicitacaoPendente(dados) &&
+                            enviarConvite(dados.id)
+                        "
                       ></app-button>
                     </td>
                   </tr>
                 }
               } @else {
-              <tr>
-              <td colspan="3">
-                <p class="empty">Nenhuma equipe para mostrar</p>
-              </td>
-            </tr> 
+                <tr>
+                  <td colspan="3">
+                    <p class="empty">Nenhuma equipe para mostrar</p>
+                  </td>
+                </tr>
               }
             }
           </tbody>

--- a/src/frontend/glitch_frontend/src/app/pages/list-group/list-group.scss
+++ b/src/frontend/glitch_frontend/src/app/pages/list-group/list-group.scss
@@ -5,6 +5,13 @@
     box-sizing: border-box;
   }
 
+  .team-table {
+    border-radius: 2%;
+  }
+  .others-teams {
+    border-radius: 4%;
+  }
+
   width: min(100%, 1320px);
   display: flex;
   flex-direction: column;
@@ -49,7 +56,7 @@
   .table-wrapper {
     width: 100%;
     background: rgba(255, 255, 255, 0.05);
-    padding: 20px;
+    border-radius: 2%;
 
     &:has(tbody tr:nth-child(n + 8)) {
       overflow-y: auto;
@@ -124,12 +131,12 @@
   display: flex;
   flex-direction: row;
   gap: 5%;
-  width: 100%;
+  width: auto;
 }
 
 .tabela-individual {
   flex: 1;
-  min-width: 0;
+  width: auto;
 }
 
 @media (min-width: 1025px) and (max-width: 1366px) {

--- a/src/frontend/glitch_frontend/src/app/pages/list-group/list-group.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/list-group/list-group.ts
@@ -21,7 +21,7 @@ export class ListGroup implements OnInit {
   constructor(
     private router: Router,
     private equipeService: EquipeService,
-    private notifService: SystemNotificationService // Adicionado para avisar se deu certo
+    private notifService: SystemNotificationService,
   ) {
     this.minhasEquipes$ = this.equipeService.minhasEquipes$;
     this.outrasEquipes$ = this.equipeService.outrasEquipes$;
@@ -29,6 +29,9 @@ export class ListGroup implements OnInit {
 
   ngOnInit() {
     this.equipeService.carregarEquipes();
+    this.router.events.subscribe(() => {
+      this.equipeService.carregarEquipes();
+    });
   }
 
   irCriarEquipe() {
@@ -39,25 +42,74 @@ export class ListGroup implements OnInit {
     const confirmacao = confirm('Tem certeza que deseja excluir esta equipe?');
 
     if (confirmacao) {
-      // CHAMA O SERVIÇO DE VERDADE AGORA:
       this.equipeService.deleteEquipe(id).subscribe({
         next: () => {
-          this.notifService.notificar('sucesso', 'Equipe excluída com sucesso!');
+          this.notifService.notificar(
+            'sucesso',
+            'Equipe excluída com sucesso!',
+          );
           this.equipeService.carregarEquipes(); // Atualiza a lista na tela na hora
         },
         error: (err) => {
           console.error(err);
           this.notifService.notificar('erro', 'Erro ao excluir a equipe.');
-        }
+        },
       });
     }
   }
 
-  enviarConvite() {
-    console.log('Enviando convite...');
+  enviarConvite(equipeId: string) {
+    const dados = localStorage.getItem('userData');
+    if (!dados) {
+      this.notifService.notificar('erro', 'Usuário não identificado.');
+      return;
+    }
+
+    const userData = JSON.parse(dados);
+    const meuNickname: string = userData.nickname;
+
+    this.equipeService
+      .convidarJogador(equipeId, {
+        nickname: meuNickname,
+        is_titular: false,
+        is_lider: false,
+        funcao: 'jogador',
+      })
+      .subscribe({
+        next: () => {
+          this.notifService.notificar(
+            'sucesso',
+            'Solicitação enviada! Aguarde a aprovação.',
+          );
+          this.equipeService.carregarEquipes();
+        },
+        error: (err) => {
+          console.error(err);
+          this.notifService.notificar('erro', 'Erro ao enviar solicitação.');
+        },
+      });
   }
 
   irParaEdicao(id: string) {
     this.router.navigate(['/groups/update', id]);
+  }
+
+  jaTemSolicitacaoPendente(equipe: Equipe): boolean {
+    const dados = localStorage.getItem('userData');
+    if (!dados) return false;
+    const { nickname } = JSON.parse(dados);
+    return equipe.membros.some(
+      (m) => m.nickname === nickname && m.dt_aceito === null,
+    );
+  }
+
+  //Função para verificar se é líder
+  isLiderDaEquipe(equipe: Equipe): boolean {
+    const dados = localStorage.getItem('userData');
+    if (!dados) return false;
+
+    const { nickname } = JSON.parse(dados);
+
+    return equipe.membros.some((m) => m.nickname === nickname && m.is_lider);
   }
 }

--- a/src/frontend/glitch_frontend/src/app/pages/players-list/players-list.component.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/players-list/players-list.component.ts
@@ -68,12 +68,6 @@ export class PlayersListComponent implements OnInit {
   }
 
   verificarEquipesParticipante(): Observable<any> {
-    console.log(
-      'Por enquanto buscamos todas as equipes pq só tem um usuário com equipe mesmo TESTE',
-    );
-
-    //   TODO: PRECISA EXISTIR UM ENDPOINT QUE TRAGA AS EQUIPES DO USUÁRIO LOGADO COM BASE NO ID DELE
-
     const headers = {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${localStorage.getItem('token')}`,

--- a/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.html
+++ b/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.html
@@ -43,14 +43,16 @@
             <th>Nome</th>
             <th>Lider</th>
             <th>Função</th>
-            <th>Ação</th>
+            @if (souLider) {
+              <th>Ação</th>
+            }
           </tr>
         </thead>
         <tbody formArrayName="membros">
           @for (
             membro of membrosControls.controls;
             let index = $index;
-            track membro
+            track membro.get("nickname")?.value
           ) {
             <tr [formGroupName]="index">
               <td>
@@ -75,17 +77,18 @@
                   "
                 ></app-input>
               </td>
-
-              <td class="buttons">
-                <app-button
-                  label=""
-                  icon="delete"
-                  size="small"
-                  color="warn"
-                  (click)="removeIntegrante(membro)"
-                  [disabled]="!souLider"
-                ></app-button>
-              </td>
+              @if (souLider) {
+                <td>
+                  <app-button
+                    label=""
+                    icon="delete"
+                    size="small"
+                    color="warn"
+                    (click)="removeIntegrante(membro)"
+                    class="botaoExcluir"
+                  ></app-button>
+                </td>
+              }
             </tr>
           }
         </tbody>
@@ -155,7 +158,7 @@
                                 : 'notSelected'
                             "
                             size="small"
-                            (click)="toggleUserSelection(jogador.nickname)"
+                            (click)="toggleUserSelection(jogador)"
                           ></app-button>
                         </td>
                       </tr>
@@ -198,14 +201,16 @@
     </div>
   }
 
-  <div>
-    <app-button
-      label="Excluir equipe"
-      icon="delete"
-      (click)="remove()"
-      color="warn"
-      class="botaoExcluir"
-      size="medium"
-    ></app-button>
-  </div>
+  @if (souLider) {
+    <div>
+      <app-button
+        label="Excluir equipe"
+        icon="delete"
+        (click)="remove()"
+        color="warn"
+        class="botaoExcluir"
+        size="medium"
+      ></app-button>
+    </div>
+  }
 </div>

--- a/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.scss
+++ b/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.scss
@@ -77,7 +77,7 @@ details {
   width: min(1100px, 92vw);
   max-width: calc(100vw - 24px);
   max-height: 85vh;
-  overflow: hidden;
+  overflow-y: auto;
   border-radius: 12px;
   background-color: var(--background);
   border: 2px solid #67679267;
@@ -203,7 +203,8 @@ details {
 }
 
 .botaoExcluir {
-  margin-left: 10%;
+  display: inline-block;
+  width: auto;
 }
 
 .table-wrapper {
@@ -228,6 +229,7 @@ details {
     word-wrap: normal;
     table-layout: fixed;
     white-space: nowrap;
+
     overflow: hidden;
 
     th,
@@ -236,6 +238,12 @@ details {
       padding: 12px;
       white-space: nowrap;
       overflow: hidden;
+    }
+
+    td .botaoExcluir {
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
 
     th {
@@ -265,6 +273,7 @@ details {
 
 .buttons {
   display: flex;
+  align-items: center;
   justify-content: center;
   gap: 8px;
 }

--- a/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/update-team/update-team.ts
@@ -11,7 +11,6 @@ import {
   Validators,
   ɵInternalFormsSharedModule,
 } from '@angular/forms';
-import { Navigation } from '../../components/navigation/navigation';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Equipe, EquipeService, Membro } from '../../services/equipe-service';
 import {
@@ -48,10 +47,13 @@ import { forkJoin } from 'rxjs';
 export class UpdateTeam implements OnInit {
   form: FormGroup;
 
-  get membrosControls(): FormArray { return this.form.get('membros') as FormArray }
-  get nomeControl(): FormControl { return this.form.get('nome') as FormControl }
-  filtroControl:FormControl = new FormControl();
-
+  get membrosControls(): FormArray {
+    return this.form.get('membros') as FormArray;
+  }
+  get nomeControl(): FormControl {
+    return this.form.get('nome') as FormControl;
+  }
+  filtroControl: FormControl = new FormControl();
 
   public getMembroControl(index: number, controlName: string): FormControl {
     const formGroup = this.membrosControls.at(index) as FormGroup;
@@ -61,7 +63,6 @@ export class UpdateTeam implements OnInit {
   private id: string | null;
 
   souLider: boolean = false;
-
 
   private equipeOriginal!: Equipe;
 
@@ -116,7 +117,7 @@ export class UpdateTeam implements OnInit {
   buscarDadosEquipe() {
     this.equipeService.getEquipePorId(this.id).subscribe({
       next: (res: Equipe) => {
-        console.log(res)
+        console.log(res);
         this.carregaDados(res);
       },
     });
@@ -156,6 +157,7 @@ export class UpdateTeam implements OnInit {
         is_titular: m.is_titular,
         funcao: m.funcao,
         dt_aceito: m.dt_aceito,
+        tipo: m.tipo,
       });
     });
     return membrosFormatado;
@@ -288,7 +290,11 @@ export class UpdateTeam implements OnInit {
       });
     });
 
-    this.sisNotifService.notificar('sucesso', 'Alterações processadas com sucesso!');
+    this.sisNotifService.notificar(
+      'sucesso',
+      'Alterações processadas com sucesso!',
+    );
+    this.equipeService.carregarEquipes();
     this.router.navigate(['/groups']);
   }
 
@@ -350,22 +356,31 @@ export class UpdateTeam implements OnInit {
   // --- FUNÇÃO DE EXCLUIR EQUIPE CORRIGIDA ---
   remove(certeza = false) {
     if (!certeza) {
-      certeza = confirm('Você tem certeza que deseja excluir a equipe? Essa ação não pode ser desfeita.');
+      certeza = confirm(
+        'Você tem certeza que deseja excluir a equipe? Essa ação não pode ser desfeita.',
+      );
     }
-    
+
     if (!certeza) return;
 
     // Usamos o this.id capturado da URL para garantir que temos o identificador
-    const idParaExcluir = this.id || (this.equipeOriginal ? this.equipeOriginal.id : null);
+    const idParaExcluir =
+      this.id || (this.equipeOriginal ? this.equipeOriginal.id : null);
 
     if (!idParaExcluir) {
-      this.sisNotifService.notificar('erro', 'ID da equipe não encontrado para exclusão');
+      this.sisNotifService.notificar(
+        'erro',
+        'ID da equipe não encontrado para exclusão',
+      );
       return;
     }
 
     this.equipeService.deleteEquipe(idParaExcluir).subscribe({
       next: () => {
-        this.sisNotifService.notificar('sucesso', 'Equipe excluída com sucesso');
+        this.sisNotifService.notificar(
+          'sucesso',
+          'Equipe excluída com sucesso',
+        );
         this.router.navigate(['/groups']); // Redireciona para a listagem
       },
       error: (e) => {
@@ -389,7 +404,7 @@ export class UpdateTeam implements OnInit {
       }
 
       this.equipeService
-        .deleteMembro(membro, this.equipeOriginal.id)
+        .deleteMembro(membro.nickname, this.equipeOriginal.id)
         .subscribe({
           next: (res) => {
             this.sisNotifService.notificar(
@@ -458,20 +473,26 @@ export class UpdateTeam implements OnInit {
     this.filtroUsuariosControl.setValue('');
     this.isInviteModalOpen = false;
   }
+  toggleUserSelection(jogador: any) {
+    const exists = Array.from(this.selectedInviteIds).some(
+      (s) => s.nickname === jogador.nickname,
+    );
 
-  toggleUserSelection(jogador:any) {
-    let jogadoresSelecionados = [...this.selectedInviteIds]
-    if (jogadoresSelecionados.some(s=>s.nickname == jogador.nickname)) {
-      this.selectedInviteIds.delete(jogador);
-      return;
+    if (exists) {
+      this.selectedInviteIds = new Set(
+        Array.from(this.selectedInviteIds).filter(
+          (s) => s.nickname !== jogador.nickname,
+        ),
+      );
+    } else {
+      this.selectedInviteIds = new Set([...this.selectedInviteIds, jogador]);
     }
-    this.selectedInviteIds.add(jogador);
-    console.log(this.selectedInviteIds)
   }
 
   isUserSelected(nickname: string): boolean {
-    let jogadoresSelecionados = [...this.selectedInviteIds]
-    return jogadoresSelecionados.some(s=>s.nickname == nickname);
+    return Array.from(this.selectedInviteIds).some(
+      (s: any) => s.nickname === nickname,
+    );
   }
 
   saveInvites() {
@@ -483,15 +504,20 @@ export class UpdateTeam implements OnInit {
     }
 
     const requests = selectedIds.map((nickname) =>
-      this.equipeService.convidarJogador(this.id!, nickname),
+      this.equipeService.convidarJogador(this.id!, {
+        nickname: nickname,
+        is_titular: true,
+        is_lider: false,
+        funcao: 'player',
+      }),
     );
 
     forkJoin(requests).subscribe({
       next: () => {
-        selectedIds.forEach((jogador) => {
+        selectedIds.forEach((nickname) => {
           this.sisNotifService.notificar(
             'sucesso',
-            `Jogador ${jogador.nickname} convidado`,
+            `Jogador ${nickname} convidado`,
           );
         });
         this.selectedInviteIds.clear();
@@ -528,5 +554,15 @@ export class UpdateTeam implements OnInit {
 
   isMobile(): boolean {
     return window.innerWidth <= 768;
+  }
+
+  //Função para verificar se é líder
+  isLiderDaEquipe(equipe: Equipe): boolean {
+    const dados = localStorage.getItem('userData');
+    if (!dados) return false;
+
+    const { nickname } = JSON.parse(dados);
+
+    return equipe.membros.some((m) => m.nickname === nickname && m.is_lider);
   }
 }

--- a/src/frontend/glitch_frontend/src/app/services/equipe-service.ts
+++ b/src/frontend/glitch_frontend/src/app/services/equipe-service.ts
@@ -9,8 +9,18 @@ export interface Membro {
   is_lider: boolean;
   is_titular: boolean;
   dt_aceito: Date;
+  tipo: 'convite' | 'solicitacao';
 }
 
+export interface Convite {
+  id: string;
+  nome: string;
+  associacoesMembro: {
+    dt_aceito: Date | null;
+    dt_saida: Date | null;
+    tipo: 'convite' | 'solicitacao';
+  }[];
+}
 export interface Equipe {
   id: string;
   nome: string;
@@ -72,11 +82,13 @@ export class EquipeService {
     const novoEstado = allEquipes.reduce(
       (acc: EquipesState, equipe: Equipe) => {
         // 4. A VERIFICAÇÃO EFICIENTE (com 'some')
-        const isMembro = equipe.membros.some(
-          (membro) => membro.nickname === currentUserNickname,
+        const membroAceito = equipe.membros.some(
+          (membro) =>
+            membro.nickname === currentUserNickname &&
+            membro.dt_aceito !== null,
         );
-        // 5. Separação
-        if (isMembro) {
+
+        if (membroAceito) {
           acc.minhasEquipes.push(equipe);
         } else {
           acc.outrasEquipes.push(equipe);
@@ -105,12 +117,24 @@ export class EquipeService {
     );
   }
 
-  public convidarJogador(equipe:string,jogador:{nickname:string,is_titular:boolean,is_lider:boolean,funcao:string}):Observable<any>{
+  public convidarJogador(
+    equipe: string,
+    jogador: {
+      nickname: string;
+      is_titular: boolean;
+      is_lider: boolean;
+      funcao: string;
+    },
+  ): Observable<any> {
     const headers = {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${localStorage.getItem('token')}`,
     };
-    return this.httpClient.post('http://localhost:3000/api/equipe/invite',{equipe,jogador},{headers})
+    return this.httpClient.post(
+      'http://localhost:3000/api/equipe/invite',
+      { equipe, jogador },
+      { headers },
+    );
   }
 
   public getEquipes(): Observable<any> {
@@ -143,33 +167,33 @@ export class EquipeService {
       headers,
     });
   }
-// equipe.service.ts
+  // equipe.service.ts
 
-aceitarConvite(equipeId: string) {
-  const headers = {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${localStorage.getItem('token')}`,
-  };
+  aceitarConvite(equipeId: string, usuarioAlvo: string) {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${localStorage.getItem('token')}`,
+    };
 
-  return this.httpClient.put(
-    'http://localhost:3000/api/equipe/aceitarInvite',
-    { equipe: equipeId },
-    { headers },
-  );
-}
+    return this.httpClient.put(
+      'http://localhost:3000/api/equipe/aceitarInvite',
+      { equipe: equipeId, usuarioAlvo: usuarioAlvo },
+      { headers },
+    );
+  }
 
-recusarConvite(equipeId: string) {
-  const headers = {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${localStorage.getItem('token')}`,
-  };
+  recusarConvite(equipeId: string, usuarioAlvo: string) {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${localStorage.getItem('token')}`,
+    };
 
-  return this.httpClient.put(
-    'http://localhost:3000/api/equipe/recusarInvite',
-    { equipe: equipeId },
-    { headers },
-  );
-}
+    return this.httpClient.put(
+      'http://localhost:3000/api/equipe/recusarInvite',
+      { equipe: equipeId, usuarioAlvo: usuarioAlvo },
+      { headers },
+    );
+  }
 
   public updateEquipe(id: string, novoNome: string): Observable<any> {
     const headers = {
@@ -214,7 +238,7 @@ recusarConvite(equipeId: string) {
     );
   }
 
-  public getMinhasEquipes():Observable<any>{
+  public getMinhasEquipes(): Observable<any> {
     const headers = {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${localStorage.getItem('token')}`,
@@ -224,5 +248,4 @@ recusarConvite(equipeId: string) {
       { headers },
     );
   }
-
 }


### PR DESCRIPTION
Backend: 
Adaptado o endpoint de adicionar integrante a equipe para que os usuários possam solicitar sua entrada a equipe também. 
Os endpoints de aceitar e recusar também foram adaptados para atender a lógica das solicitações de entrada.
Regra adicionada: somente o líder visualiza e pode responder as solitações de entrada. 
Criada migration para membros_equipe incluir o tipo do convite que pode ser apenas solicitacao ou convite. 

Frontend: 
No dashboard o usuário pdoe visualizar os convites que recebeu e caso seja líder de alguma equipe com, solicitações de entrada estas também aparecerão, se não houver, esse quadro não é apresentado. 
Há os botões de aceitar e recusar integrados ao backend, tanto para convites quanto para solicitações. 
No criar equipe ele usa o convidar para os usuários que serão adicionados. 
Na lista de equipes em "Outras equipes" (equipes que não faço parte) há um botão integrado onde posso solicitar para entrar nessa equipe. 
No editar uma equipe eu posso convidar usuários a participarem da minha equipe, integrado com backend.

Outras melhorias: 
Somente o líder pode excluir membros da equipe e excluir a própria equipe. Caso eu não seja, os botões nem são apresentados na tela. 