### PR TITLE
fix: integra botões da landing page

### DIFF
--- a/src/frontend/glitch_frontend/src/app/pages/landing-page/landing-page.html
+++ b/src/frontend/glitch_frontend/src/app/pages/landing-page/landing-page.html
@@ -81,10 +81,10 @@
                   </span>
                 </div>
                 <div class="card-footer">
-                  <button class="btn-card-footer">
+                  <button class="btn-card-footer" (click)="verTorneio(t.codigo || t.id)">
                     <mat-icon>visibility</mat-icon> Ver
                   </button>
-                  <button class="btn-card-footer">
+                  <button class="btn-card-footer" (click)="participarTorneio(t.codigo || t.id)">
                     <mat-icon>joystick</mat-icon>Participar
                   </button>
                 </div>
@@ -118,10 +118,10 @@
                   </span>
                 </div>
                 <div class="card-footer">
-                  <button class="btn-card-footer">
+                  <button class="btn-card-footer" (click)="verTorneio(t.codigo || t.id)">
                     <mat-icon>visibility</mat-icon> Ver
                   </button>
-                  <button class="btn-card-footer">
+                  <button class="btn-card-footer" (click)="participarTorneio(t.codigo || t.id)">
                     <mat-icon>joystick</mat-icon>Participar
                   </button>
                 </div>

--- a/src/frontend/glitch_frontend/src/app/pages/landing-page/landing-page.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/landing-page/landing-page.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { Carrousel } from '../../components/carrousel/carrousel';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { TournamentService } from '../../services/tournament-service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-landing-page',
@@ -29,9 +30,31 @@ export class LandingPageComponent {
   finalizados$: Observable<any[]> = this.finalizadosSubject.asObservable();
   ranking$: Observable<any[]> = this.rankingSubject.asObservable();
 
-  constructor(private tournamentService: TournamentService) {
+  constructor(
+    private tournamentService: TournamentService,
+    private router: Router,
+  ) {
     this.buscarTorneios();
     this.buscarRanking();
+  }
+
+  verTorneio(id: string) {
+    console.log('VER ID enviado:', id);
+    
+    this.router.navigate(['/login'], {
+      queryParams: {
+        redirect: `/tournaments/details/${id}`,
+      },
+    });
+  }
+
+  participarTorneio(id: string) {
+    console.log('Participar torneio:', id);
+
+    this.router.navigate(['/login'], {
+      queryParams: {
+        redirect: '/tournaments',},
+    });
   }
 
   private buscarTorneios() {

--- a/src/frontend/glitch_frontend/src/app/pages/login/login.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/login/login.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { InputComponent } from "../../components/input/input";
 import { ButtonComponent } from "../../components/button/button";
 import { FormControl, FormGroup, Validators } from '@angular/forms';
@@ -25,7 +25,13 @@ export class LoginComponent {
   get nicknameControl():FormControl{return this.form.get('nickname') as FormControl}
   get senhaControl():FormControl{return this.form.get('senha') as FormControl}
 
-  constructor(private authService:AuthenticationService,private router:Router,private usuarioService:UsuarioService,private sysNotifService:SystemNotificationService){}
+  constructor(
+    private authService:AuthenticationService,
+    private router:Router,
+    private route: ActivatedRoute,
+    private usuarioService:UsuarioService,
+    private sysNotifService:SystemNotificationService
+  ){}
 
   login(){
     this.form.markAllAsTouched();
@@ -39,7 +45,9 @@ export class LoginComponent {
             next:(dadosUsuario)=>{
               this.sysNotifService.notificar('sucesso','Entrando...')
               localStorage.setItem('userData',JSON.stringify(dadosUsuario))
-              this.router.navigate(['/dashboard'])
+
+              const redirect = this.route.snapshot.queryParamMap.get('redirect');
+              this.router.navigateByUrl(redirect || '/dashboard');
             }
           })
 


### PR DESCRIPTION
### Correções realizadas – Landing Page (Bug 14)

* Integração dos botões **“Ver”** e **“Participar”** na Landing Page.
* Implementado redirecionamento para autenticação quando o usuário não estiver logado.
* Ajustado fluxo de navegação após login utilizando parâmetro `redirect`.
* Botão **“Ver”** agora redireciona corretamente para a página de detalhes do torneio (`/tournaments/details/:id`).
* Botão **“Participar”** agora redireciona o usuário autenticado para a listagem de torneios (`/tournaments`) para continuidade da inscrição.
* Correção no fluxo de login para respeitar a rota de origem ao invés de redirecionar sempre para o dashboard.
* Ajustes realizados nos arquivos:

  * `landing-page.html`
  * `landing-page.ts`
  * `login.ts`
