### PR TITLE
Correções em torneios - front e back

### DIFF
--- a/src/backend/glitch_api/src/controllers/partida.controller.ts
+++ b/src/backend/glitch_api/src/controllers/partida.controller.ts
@@ -80,7 +80,7 @@ export class PartidaController{
         let partida = req.body.partida;
         let chave = req.body.chaveamento;
         let vencedor = req.body.vencedor;
-        if(!etapa || !partida || !vencedor){
+        if(!etapa || !partida || !chave || !vencedor){
             res.status(400).json({message:"Dados faltando"})
             return;
         }
@@ -89,7 +89,22 @@ export class PartidaController{
             await partidaService.finalizarPartida(etapa,partida,chave,vencedor);
             res.status(200).json({message:'ok'})
         }catch(e){
-            res.status(500).json({message:'Erro interno do servidor'})
+            const message = e instanceof Error ? e.message : 'Erro interno do servidor';
+            const normalized = message
+              .normalize('NFD')
+              .replace(/[\u0300-\u036f]/g, '')
+              .toLowerCase();
+
+            if (
+              normalized.includes('dados nao encontrados') ||
+              normalized.includes('vencedor nao esta na lista') ||
+              normalized.includes('quantidade impar')
+            ) {
+              res.status(400).json({ message });
+              return;
+            }
+
+            res.status(500).json({message})
         }
     }
 
@@ -100,11 +115,26 @@ export class PartidaController{
             return;
         }
         try{
-            await partidaService.finalizaEtapa(etapa)
-            res.status(200).json({message:'ok'})
+            const resultado = await partidaService.finalizaEtapa(etapa)
+            res.status(200).json({message:'ok', resultado})
         }catch(e){
             console.log(e)
-            res.status(500).json({message:"Erro interno no servidor"})
+            const message = e instanceof Error ? e.message : 'Erro interno no servidor';
+            const normalized = message
+              .normalize('NFD')
+              .replace(/[\u0300-\u036f]/g, '')
+              .toLowerCase();
+
+            if (
+              normalized.includes('etapa nao encontrada') ||
+              normalized.includes('sem vencedores') ||
+              normalized.includes('quantidade impar')
+            ) {
+              res.status(400).json({ message });
+              return;
+            }
+
+            res.status(500).json({message})
         }
     }
 

--- a/src/backend/glitch_api/src/controllers/torneio.controller.ts
+++ b/src/backend/glitch_api/src/controllers/torneio.controller.ts
@@ -22,7 +22,7 @@ export class TorneioController {
                 } else {
                     res.status(500).json({ message: 'Erro no servidor' })
                 }
-            } catch (e) {
+            } catch (e) { 
                 res.status(500).json({ message: "Erro interno" })
             }
         } else {
@@ -133,6 +133,7 @@ export class TorneioController {
             switch (status) {
                 case 200: res.status(200).json({ message: 'Gerado' }); break;
                 case 404: res.status(404).json({ message: 'Não encontrado' }); break;
+                case 422: res.status(422).json({ message: 'Participantes insuficientes pra iniciar o torneio'})
             }
         } catch (e) {
             console.log(e)

--- a/src/backend/glitch_api/src/controllers/torneio.controller.ts
+++ b/src/backend/glitch_api/src/controllers/torneio.controller.ts
@@ -342,7 +342,28 @@ export class TorneioController {
       res.status(200).json({ message: "ok" });
     } catch (e) {
       console.log(e);
-      res.status(500).json({ message: "Erro interno do servidor" });
+      const message =
+        e instanceof Error ? e.message : "Erro interno do servidor";
+
+      const normalized = message
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase();
+
+      if (
+        normalized.includes("partidas agendadas") ||
+        normalized.includes("iniciada sem pontuacao")
+      ) {
+        res.status(400).json({ message });
+        return;
+      }
+
+      if (normalized.includes("torneio nao encontrado")) {
+        res.status(404).json({ message });
+        return;
+      }
+
+      res.status(500).json({ message });
     }
   }
 

--- a/src/backend/glitch_api/src/controllers/torneio.controller.ts
+++ b/src/backend/glitch_api/src/controllers/torneio.controller.ts
@@ -192,19 +192,29 @@ export class TorneioController {
         torneio,
         usuario,
       );
-
       res.status(200).json({ message: "entrou" });
     } catch (e) {
-      switch (e) {
-        case 400:
-          res.status(400).json({ message: "Limite atingido" });
-          break;
-        case 404:
-          res.status(404).json({ message: "Não encontrado" });
-          break;
-        default:
-          res.status(500).json({ message: "Erro interno do servidor" });
+      const message =
+        e instanceof Error ? e.message : "Erro interno do servidor";
+      const normalized = message
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase();
+      if (
+        normalized.includes("limite de participantes") ||
+        normalized.includes("não aceita ingresso")
+      ) {
+        res.status(400).json({ message });
+        return;
       }
+      if (
+        normalized.includes("não foi encontrado") ||
+        normalized.includes("não encontrado")
+      ) {
+        res.status(404).json({ message });
+        return;
+      }
+      res.status(500).json({ message });
       console.log(e);
     }
   }
@@ -221,19 +231,29 @@ export class TorneioController {
         torneio,
         equipe,
       );
-
       res.status(200).json({ message: "entrou" });
     } catch (e) {
-      switch (e) {
-        case 400:
-          res.status(400).json({ message: "Limite atingido" });
-          break;
-        case 404:
-          res.status(404).json({ message: "Não encontrado" });
-          break;
-        default:
-          res.status(500).json({ message: "Erro interno do servidor" });
+      const message =
+        e instanceof Error ? e.message : "Erro interno do servidor";
+      const normalized = message
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase();
+      if (
+        normalized.includes("limite de participantes") ||
+        normalized.includes("nao aceita ingresso")
+      ) {
+        res.status(400).json({ message });
+        return;
       }
+      if (
+        normalized.includes("nao foi encontrado") ||
+        normalized.includes("nao encontrado")
+      ) {
+        res.status(404).json({ message });
+        return;
+      }
+      res.status(500).json({ message });
       console.log(e);
     }
   }
@@ -264,7 +284,35 @@ export class TorneioController {
       res.status(200).json({ message: "Gerado" });
     } catch (e) {
       console.log(e);
-      res.status(500).json({ message: "Erro ao gerar partidas" });
+
+      const message =
+        e instanceof Error ? e.message : "Erro interno ao gerar partidas";
+
+      const normalized = message
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase();
+
+      if (normalized.includes("torneio nao encontrado")) {
+        res.status(404).json({ message });
+        return;
+      }
+
+      if (normalized.includes("ja foram geradas")) {
+        res.status(409).json({ message });
+        return;
+      }
+
+      if (
+        normalized.includes("Não há participantes") ||
+        normalized.includes("pelo menos 2 participantes") ||
+        normalized.includes("impossível jogar")
+      ) {
+        res.status(400).json({ message });
+        return;
+      }
+
+      res.status(500).json({ message });
     }
   }
 

--- a/src/backend/glitch_api/src/services/partida.service.ts
+++ b/src/backend/glitch_api/src/services/partida.service.ts
@@ -1,4 +1,5 @@
-import { Op } from "sequelize";
+import { randomInt, randomUUID } from "crypto";
+import { Op, Transaction } from "sequelize";
 import { sequelize } from "../config/database.config";
 import models from "../models/index.models";
 
@@ -170,6 +171,162 @@ export class PartidaService {
         }
     }
 
+    private nomearEtapaPorQuantidade(quantidadeParticipantes: number, ordem: number): string {
+        switch (quantidadeParticipantes) {
+            case 2:
+                return "FINAL";
+            case 4:
+                return "SEMIFINAL";
+            default:
+                return `RODADA ${ordem}`;
+        }
+    }
+
+    private embaralharParticipantes(ids: string[]): string[] {
+        const arr = [...ids];
+        for (let i = arr.length - 1; i > 0; i--) {
+            const j = randomInt(i + 1);
+            [arr[i], arr[j]] = [arr[j], arr[i]];
+        }
+        return arr;
+    }
+
+    private async buscarParticipantesAtivosMataMata(torneio_id: string, transaction: Transaction): Promise<string[]> {
+        const participantesAprovados = (await models.Participantes.findAll({
+            attributes: ["id"],
+            where: { torneio_id, status: "APROVADO" },
+            order: [["dt_inscricao", "ASC"], ["id", "ASC"]],
+            transaction,
+            raw: true,
+        })) as unknown as Array<{ id: string }>;
+
+        const todosParticipantes = participantesAprovados.map((p) => p.id);
+        if (todosParticipantes.length === 0) return [];
+
+        const confrontosComVencedor = await models.Chaveamentos.findAll({
+            attributes: ["participante_a_id", "participante_b_id", "vencedor_id"],
+            where: { vencedor_id: { [Op.not]: null } as any },
+            include: [
+                {
+                    model: models.Partidas,
+                    as: "partida",
+                    attributes: ["id"],
+                    include: [
+                        {
+                            model: models.EtapasPartida,
+                            as: "etapa",
+                            attributes: ["id"],
+                            where: { torneio_id },
+                        },
+                    ],
+                },
+            ],
+            transaction,
+        });
+
+        const eliminados = new Set<string>();
+        for (const confronto of confrontosComVencedor as any[]) {
+            const a = confronto?.participante_a_id as string;
+            const b = confronto?.participante_b_id as string;
+            const vencedor = confronto?.vencedor_id as string | null;
+
+            if (!a || !b || !vencedor) continue;
+            if (vencedor === a) eliminados.add(b);
+            else if (vencedor === b) eliminados.add(a);
+        }
+
+        return todosParticipantes.filter((id) => !eliminados.has(id));
+    }
+
+    private async gerarProximaEtapaMataMata(etapa_id: string, transaction: Transaction): Promise<any> {
+        const etapaAtual = await models.EtapasPartida.findByPk(etapa_id, { transaction });
+        if (!etapaAtual) {
+            throw new Error("Etapa nao encontrada");
+        }
+
+        const proximaOrdem = etapaAtual.dataValues.ordem + 1;
+        const torneio_id = etapaAtual.dataValues.torneio_id;
+
+        const proximaEtapaJaExiste = await models.EtapasPartida.count({
+            where: { torneio_id, ordem: proximaOrdem },
+            transaction,
+        });
+        if (proximaEtapaJaExiste > 0) {
+            return { gerouProximaEtapa: false, campeaoId: null };
+        }
+
+        const ativos = await this.buscarParticipantesAtivosMataMata(torneio_id, transaction);
+        if (ativos.length === 0) {
+            throw new Error("Nao foi possivel determinar participantes ativos no mata-mata");
+        }
+
+        if (ativos.length === 1) {
+            await models.Torneios.update(
+                { dt_fim: new Date() },
+                { where: { id: torneio_id, dt_fim: null }, transaction },
+            );
+            return { gerouProximaEtapa: false, campeaoId: ativos[0] };
+        }
+
+        const participantesParaConfronto = this.embaralharParticipantes(ativos);
+        let byeParticipanteId: string | null = null;
+        if (participantesParaConfronto.length % 2 !== 0) {
+            byeParticipanteId = participantesParaConfronto.shift() ?? null;
+        }
+
+        const proximaEtapaId = randomUUID();
+        await models.EtapasPartida.create(
+            {
+                id: proximaEtapaId,
+                torneio_id,
+                ordem: proximaOrdem,
+                tipo_etapa: this.nomearEtapaPorQuantidade(ativos.length, proximaOrdem),
+                is_concluida: false,
+            },
+            { transaction },
+        );
+
+        const partidasGeradas: any[] = [];
+        const chaveamentosGerados: any[] = [];
+
+        for (let i = 0; i < participantesParaConfronto.length; i += 2) {
+            const participanteA = participantesParaConfronto[i];
+            const participanteB = participantesParaConfronto[i + 1];
+            const partidaId = randomUUID();
+
+            partidasGeradas.push({
+                id: partidaId,
+                etapa_id: proximaEtapaId,
+                dt_inicio: new Date(),
+                situacao: "AGENDADA",
+            });
+
+            chaveamentosGerados.push({
+                id: randomUUID(),
+                partida_id: partidaId,
+                participante_a_id: participanteA,
+                participante_b_id: participanteB,
+                vencedor_id: undefined,
+                ordem: i / 2 + 1,
+                placar_a: 0,
+                placar_b: 0,
+                criterio_desempate: "PONTOS",
+                is_a_pronto: true,
+                is_b_pronto: true,
+            });
+        }
+
+        await models.Partidas.bulkCreate(partidasGeradas, { transaction });
+        await models.Chaveamentos.bulkCreate(chaveamentosGerados, { transaction });
+
+        return {
+            gerouProximaEtapa: true,
+            campeaoId: null,
+            etapaId: proximaEtapaId,
+            byeParticipanteId,
+        };
+    }
+
 
     async finalizarPartida(etapa_id: string, partida_id: string, chave_id: string, vencedor_id: string): Promise<any> {
         let transaction = await sequelize.transaction();
@@ -192,7 +349,7 @@ export class PartidaService {
                 situacao: "FINALIZADA"
             }, { transaction })
 
-            await this.finalizaEtapa(etapa_id)
+            await this.finalizaEtapa(etapa_id, transaction)
             await transaction.commit()
         } catch (e) {
             await transaction.rollback()
@@ -200,32 +357,49 @@ export class PartidaService {
         }
     }
 
-    async todasPartidasFinalizadas(etapa_id: string): Promise<boolean> {
+    async todasPartidasFinalizadas(etapa_id: string, transaction?: Transaction): Promise<boolean> {
         try {
-            let countEtapas = await models.EtapasPartida.count({ where: { id: etapa_id } })
+            let countEtapas = await models.EtapasPartida.count({ where: { id: etapa_id }, transaction })
             if (countEtapas != 1) {
-                throw new Error("Etapa não encontrada")
+                throw new Error("Etapa nao encontrada")
             }
-            let partidas = await models.Partidas.findAll({ where: { etapa_id, situacao: { [Op.not]: 'FINALIZADA' } } });
-            console.log(partidas)
+            let partidas = await models.Partidas.findAll({
+                where: { etapa_id, situacao: { [Op.not]: 'FINALIZADA' } },
+                transaction,
+            });
             return partidas.length == 0
         } catch (e) {
             throw e
         }
     }
 
-    async finalizaEtapa(etapa_id: string): Promise<any> {
+    async finalizaEtapa(etapa_id: string, transaction?: Transaction): Promise<any> {
+        const possuiTransacaoExterna = !!transaction;
+        const tx = transaction ?? await sequelize.transaction();
         try {
 
-            if (await this.todasPartidasFinalizadas(etapa_id)) {
+            if (await this.todasPartidasFinalizadas(etapa_id, tx)) {
                 await models.EtapasPartida.update({
                     is_concluida: true
-                }, { where: { id: etapa_id } })
-                return true;
+                }, { where: { id: etapa_id }, transaction: tx })
+
+                const resultado = await this.gerarProximaEtapaMataMata(etapa_id, tx)
+
+                if (!possuiTransacaoExterna) {
+                    await tx.commit();
+                }
+                return { etapaFinalizada: true, ...resultado };
+            }
+
+            if (!possuiTransacaoExterna) {
+                await tx.commit();
             }
 
             return false;
         } catch (e) {
+            if (!possuiTransacaoExterna) {
+                await tx.rollback();
+            }
             throw e
         }
     }

--- a/src/backend/glitch_api/src/services/torneio.service.ts
+++ b/src/backend/glitch_api/src/services/torneio.service.ts
@@ -305,23 +305,33 @@ export class TorneioService {
     }
 
     async gerarPartidas(torneio_id: string) {
-        let transaction = await sequelize.transaction();
-        try {
-            let torneio = await models.Torneios.findByPk(torneio_id, { transaction })
-            if (!torneio) return 404;
-            let participantes = await models.Participantes.findAll({ where: { torneio_id: torneio.dataValues.id }, transaction, raw: true, nest: true }) as unknown as ParticipantesAtributos[]
-            if (!participantes) return 404;
-            let gerado = this.gerar(torneio_id, participantes);
-            await models.EtapasPartida.bulkCreate(gerado.etapasGeradas, { transaction });
-            await models.Partidas.bulkCreate(gerado.partidasGeradas, { transaction });
-            await models.Chaveamentos.bulkCreate(gerado.chaveamentosGerados, { transaction });
-            await transaction.commit()
-            return 200
-        } catch (e) {
+    let transaction = await sequelize.transaction();
+    try {
+        let torneio = await models.Torneios.findByPk(torneio_id, { transaction })
+        if (!torneio) return 404;
+        let participantes = await models.Participantes.findAll({ where: { torneio_id: torneio.dataValues.id }, transaction, raw: true, nest: true }) as unknown as ParticipantesAtributos[]
+        if (!participantes) return 404;
+
+        // Validação de mínimo de participantes
+        let configInscricao = await models.ConfigsInscricao.findOne({ where: { torneio_id: torneio.dataValues.id }, transaction });
+        const minimoConfigurado = configInscricao?.dataValues.qtd_participantes_max ?? 2;
+        const minimoNecessario = Math.max(2, minimoConfigurado);
+        if (participantes.length < minimoNecessario) {
             await transaction.rollback();
-            throw e;
+            return 422;
         }
+
+        let gerado = this.gerar(torneio_id, participantes);
+        await models.EtapasPartida.bulkCreate(gerado.etapasGeradas, { transaction });
+        await models.Partidas.bulkCreate(gerado.partidasGeradas, { transaction });
+        await models.Chaveamentos.bulkCreate(gerado.chaveamentosGerados, { transaction });
+        await transaction.commit()
+        return 200
+    } catch (e) {
+        await transaction.rollback();
+        throw e;
     }
+}
 
     private gerar(torneioId: string, participantes: ParticipantesAtributos[], numRodadas: number = 1) {
         let pool = participantes.map(p => p.id);

--- a/src/backend/glitch_api/src/services/torneio.service.ts
+++ b/src/backend/glitch_api/src/services/torneio.service.ts
@@ -240,6 +240,9 @@ export class TorneioService {
           "dt_inicio",
           "dt_fim",
           "aceita_ingresso",
+          "qtd_participantes_max",
+          "tipo_inscricao",
+          "dt_limite_ingresso",
         ],
         include: [
           includeJogo,

--- a/src/backend/glitch_api/src/services/torneio.service.ts
+++ b/src/backend/glitch_api/src/services/torneio.service.ts
@@ -239,6 +239,7 @@ export class TorneioService {
           "descricao",
           "dt_inicio",
           "dt_fim",
+          "aceita_ingresso",
         ],
         include: [
           includeJogo,
@@ -579,11 +580,15 @@ export class TorneioService {
     let transaction = await sequelize.transaction();
     try {
       let torneio = await models.Torneios.findByPk(torneio_id, {
-        attributes: ["id"],
+        attributes: ["id", "aceita_ingresso"],
       });
 
       if (!torneio) {
         throw new Error("Torneio não foi encontrado");
+      }
+
+      if (torneio.dataValues.aceita_ingresso === false) {
+        throw new Error("Este torneio não aceita mais integrantes");
       }
 
       let configInscricao = await models.ConfigsInscricao.findOne({
@@ -638,7 +643,7 @@ export class TorneioService {
     let transaction = await sequelize.transaction();
     try {
       let torneio = await models.Torneios.findOne({
-        attributes: ["id"],
+        attributes: ["id", "aceita_ingresso"],
         where: {
           id: torneio_id,
         },
@@ -646,6 +651,10 @@ export class TorneioService {
 
       if (!torneio) {
         throw new Error("Torneio não foi encontrado");
+      }
+
+      if (torneio.dataValues.aceita_ingresso === false) {
+        throw new Error("Este torneio não aceita mais integrantes");
       }
 
       let configInscricao = await models.ConfigsInscricao.findOne({
@@ -923,18 +932,38 @@ export class TorneioService {
     try {
       let torneio = await models.Torneios.findByPk(torneio_id, { transaction });
       if (!torneio) {
-        throw new Error("Torneio não encontrado");
+        throw new Error("Torneio nao encontrado");
+      }
+
+      const etapasExistentes = await models.EtapasPartida.count({
+        where: { torneio_id: torneio.dataValues.id },
+        transaction,
+      });
+
+      if (etapasExistentes > 0) {
+        throw new Error("Partidas já foram geradas para este torneio");
       }
 
       let participantes = (await models.Participantes.findAll({
-        where: { torneio_id: torneio.dataValues.id },
+        where: {
+          torneio_id: torneio.dataValues.id,
+          status: "APROVADO",
+        },
         transaction,
         raw: true,
         nest: true,
       })) as unknown as ParticipantesAtributos[];
 
-      if (!participantes) {
-        throw new Error("participantes não encontrados");
+      if (!participantes || participantes.length === 0) {
+        throw new Error(
+          "Nao ha participantes aprovados para gerar partidas neste torneio",
+        );
+      }
+
+      if (participantes.length < 2) {
+        throw new Error(
+          "E necessario pelo menos 2 participantes aprovados para gerar partidas",
+        );
       }
 
       let gerado = this.gerar(torneio_id, participantes);
@@ -978,7 +1007,7 @@ export class TorneioService {
     // Validação de integridade
     if (numRodadas > maxRodadasPossiveis) {
       throw new Error(
-        `Impossível jogar ${numRodadas} rodadas únicas com apenas ${participantes.length} participantes.`,
+        `Impossivel jogar ${numRodadas} rodadas unicas com apenas ${participantes.length} participantes.`,
       );
     }
 

--- a/src/backend/glitch_api/src/services/torneio.service.ts
+++ b/src/backend/glitch_api/src/services/torneio.service.ts
@@ -1089,10 +1089,78 @@ export class TorneioService {
 
   async finalizarTorneio(torneio_id: string): Promise<any> {
     try {
-      let torneio = await models.Torneios.update(
-        {
-          dt_fim: new Date(),
+      const torneio = await models.Torneios.findByPk(torneio_id, {
+        attributes: ["id", "dt_fim"],
+      });
+
+      if (!torneio) {
+        throw new Error("Torneio nao encontrado");
+      }
+
+      const partidasAgendadas = await models.Partidas.count({
+        include: [
+          {
+            model: models.EtapasPartida,
+            as: "etapa",
+            attributes: [],
+            where: { torneio_id },
+          },
+        ],
+        where: {
+          situacao: {
+            [Op.in]: ["AGENDADA", "NÃO INICIADO", "NAO INICIADO"] as any,
+          },
         },
+      });
+
+      if (partidasAgendadas > 0) {
+        throw new Error("Nao e possivel finalizar: existem partidas agendadas");
+      }
+
+      const partidasEmAndamento = await models.Partidas.findAll({
+        attributes: ["id", "situacao"],
+        include: [
+          {
+            model: models.EtapasPartida,
+            as: "etapa",
+            attributes: [],
+            where: { torneio_id },
+          },
+          {
+            model: models.Chaveamentos,
+            as: "chaveamentos",
+            attributes: ["vencedor_id", "placar_a", "placar_b"],
+          },
+        ],
+        where: { situacao: "EM PROGRESSO" },
+      });
+
+      const existePartidaIniciadaSemPontuacao = partidasEmAndamento.some(
+        (partida: any) => {
+          const chaveamentos = Array.isArray(partida?.chaveamentos)
+            ? partida.chaveamentos
+            : [];
+
+          if (chaveamentos.length === 0) {
+            return true;
+          }
+
+          return chaveamentos.every((ch: any) => {
+            const placarA = Number(ch?.placar_a ?? 0);
+            const placarB = Number(ch?.placar_b ?? 0);
+            return !ch?.vencedor_id && placarA <= 0 && placarB <= 0;
+          });
+        },
+      );
+
+      if (existePartidaIniciadaSemPontuacao) {
+        throw new Error(
+          "Nao e possivel finalizar: existe partida iniciada sem pontuacao registrada",
+        );
+      }
+
+      await models.Torneios.update(
+        { dt_fim: new Date() },
         { where: { id: torneio_id } },
       );
       return true;

--- a/src/frontend/glitch_frontend/src/app/pages/tournament-list/tournament-list.html
+++ b/src/frontend/glitch_frontend/src/app/pages/tournament-list/tournament-list.html
@@ -124,6 +124,7 @@
                         </app-button>
                       } @else if (
                         t.configuracao_inscricao &&
+                        t.aceita_ingresso !== false &&
                         (t.participantes?.length ?? 0) <
                           t.configuracao_inscricao?.qtd_participantes_max &&
                         !t.isMembro

--- a/src/frontend/glitch_frontend/src/app/pages/tournament-list/tournament-list.html
+++ b/src/frontend/glitch_frontend/src/app/pages/tournament-list/tournament-list.html
@@ -122,13 +122,7 @@
                           title="Iniciar"
                         >
                         </app-button>
-                      } @else if (
-                        t.configuracao_inscricao &&
-                        t.aceita_ingresso !== false &&
-                        (t.participantes?.length ?? 0) <
-                          t.configuracao_inscricao?.qtd_participantes_max &&
-                        !t.isMembro
-                      ) {
+                      } @else if (canJoinTournament(t)) {
                         <app-button
                           label="Ingressar"
                           icon="login"

--- a/src/frontend/glitch_frontend/src/app/pages/tournament-list/tournament-list.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/tournament-list/tournament-list.ts
@@ -199,11 +199,53 @@ export class TournamentList implements OnInit {
     this.router.navigate(['/tournaments/create-tournament']);
   }
 
-  joinTournament(t: any) {
-    this.subscriptionService.subscribe(
-      t.codigo,
-      t.configuracao_inscricao.modo_inscricao.toLowerCase(),
+  private obterModoInscricao(t: any): 'individual' | 'grupo' | null {
+    const modo = String(
+      t?.configuracao_inscricao?.modo_inscricao ?? t?.tipo_inscricao ?? '',
+    )
+      .trim()
+      .toLowerCase();
+
+    if (modo === 'individual') return 'individual';
+    if (modo === 'grupo') return 'grupo';
+    return null;
+  }
+
+  private obterLimiteParticipantes(t: any): number | null {
+    const limite = Number(
+      t?.configuracao_inscricao?.qtd_participantes_max ??
+        t?.qtd_participantes_max,
     );
+
+    if (!Number.isFinite(limite) || limite <= 0) return null;
+    return limite;
+  }
+
+  canJoinTournament(t: any): boolean {
+    if (!t || t.dt_fim) return false;
+    if (t.responsavel?.organizador === this.currentUser) return false;
+    if (t.aceita_ingresso === false) return false;
+    if (t.isMembro) return false;
+
+    const limite = this.obterLimiteParticipantes(t);
+    const inscritos = Array.isArray(t.participantes) ? t.participantes.length : 0;
+    if (limite !== null && inscritos >= limite) return false;
+
+    return this.obterModoInscricao(t) !== null;
+  }
+
+  joinTournament(t: any) {
+    const modo = this.obterModoInscricao(t);
+
+    if (!modo) {
+      this.notifService.notificar(
+        'erro',
+        'Não foi possível identificar o modo de inscrição do torneio.',
+      );
+      return;
+    }
+
+    this.subscriptionService.subscribe(t.codigo, modo);
   }
 
   editTournament(t: string) {

--- a/src/frontend/glitch_frontend/src/app/pages/tournament-manage/tournament-manage.html
+++ b/src/frontend/glitch_frontend/src/app/pages/tournament-manage/tournament-manage.html
@@ -92,16 +92,20 @@
     }
   </div>
   <div class="right">
-    <h2>Lista de participantes</h2>
-    <ul>
-      @if (dadosTorneio | async; as torneio) {
+  <h2>Lista de participantes</h2>
+  <ul>
+    @if (dadosTorneio | async; as torneio) {
+      @if (torneio.participantes && torneio.participantes.length > 0) {
         @for (
           participante of torneio.participantes;
           track participante.usuario.nickname
         ) {
           <li>{{ participante.usuario.nickname }}</li>
         }
+      } @else {
+        <li class="sem-participantes">Nenhum participante inscrito</li>
       }
-    </ul>
-  </div>
+    }
+  </ul>
+</div>
 </div>

--- a/src/frontend/glitch_frontend/src/app/pages/tournament-manage/tournament-manage.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/tournament-manage/tournament-manage.ts
@@ -132,7 +132,8 @@ export class TournamentManage implements OnInit {
         this.router.navigate(['/tournaments'])
       },
       error:(err)=>{
-        this.notifService.notificar('erro','Erro ao finalizar torneio')
+        const message = err?.error?.message || 'Erro ao finalizar torneio';
+        this.notifService.notificar('erro', message)
         console.log(err)
       }
     })

--- a/src/frontend/glitch_frontend/src/app/pages/tournament-manage/tournament-manage.ts
+++ b/src/frontend/glitch_frontend/src/app/pages/tournament-manage/tournament-manage.ts
@@ -62,7 +62,7 @@ export class TournamentManage implements OnInit {
     this.tournamentService.getPartidasDoTorneio(this.id).subscribe({
       next: (res) => {
         if(res.length == 0){
-          this.gerarPartidas()
+          this.arrPartidasSubject.next([])
           return;
         }
         res.forEach((e:any)=>{
@@ -79,6 +79,17 @@ export class TournamentManage implements OnInit {
   }
 
   gerarPartidas() {
+    const torneioAtual = this.dadosTorneioSubject.getValue();
+    const qtdParticipantes = (torneioAtual?.participantes ?? []).length;
+
+    if (qtdParticipantes < 2) {
+      this.notifService.notificar(
+        'erro',
+        'É necessário pelo menos 2 participantes para gerar partidas.',
+      );
+      return;
+    }
+
     this.tournamentService.gerarPartidas(this.id).subscribe({
       next: (res) => {
         console.log(res)
@@ -87,7 +98,8 @@ export class TournamentManage implements OnInit {
         this.buscaPartidas();
       },
       error: (err) => {
-        this.notifService.notificar('erro',err.error.message)
+        const message = err?.error?.message || 'Erro ao gerar partidas';
+        this.notifService.notificar('erro', message)
         console.log(err)
       }
     })


### PR DESCRIPTION
**Bug 11- Erro ao iniciar partida:** estava gerando erro nos torneios com menos de 2 integrantes, não é possível iniciar. Por isso, fiz um tratamento com situações de erros mais especificas dinalziando o usuário através das notificações. 

**IMP6 - Impedir inscrição de jogadores em torneios que já foram iniciados:** proteção tanto no backend quanto no frontend, nesses casos o botão ingressar nem aparece. 

**IMP7 - Prevenir finalização precoce do torneio:** Enquanto houver partidas geradas, mas sem resultado, o torneio não pode ser finalizado e isso é avisado ao usuário visulamente. Caso não tenha partidas em aberto, podendo terem sido finalizadas partidas anteriormente ou não, o torneio pode ser encerrado.

**Bug 28 - Chaves de torneio e definição do vencedor:** sistema mata-mata, quem perde é eliminado do torneio, os vencedores passam para próxima etapa, sempre são aleatorizados os participantes das partidas. Caso número seja ímpar, um dos participantes é "sorteado" para avançar automaticamente para próxima etapa. As etapas que possum título diferenciado são semifinal e final, as demais ficam como rodada X (número da rodada atual dependendo da situação). 